### PR TITLE
docs: add .env.example documenting configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# FreeDeepseekAPI — example configuration.
+# All variables are optional; the defaults shown below are what the code uses.
+# Copy this file to .env and override as needed (a real .env is gitignored).
+
+# ── HTTP server ──
+PORT=9655
+HOST=0.0.0.0
+
+# ── Account auth source ──
+# The pool loads DeepSeek accounts from files. Use either a single file or a
+# directory of *.json files (one account per file).
+DEEPSEEK_AUTH_PATH=./deepseek-auth.json
+# DEEPSEEK_AUTH_DIR=./data/accounts
+
+# ── Account pool ──
+# Cooldown in milliseconds applied to an account after HTTP 401/403/429
+# (default: 600000 = 10 minutes).
+DEEPSEEK_ACCOUNT_COOLDOWN_MS=600000
+
+# ── Startup (deploy / CI) ──
+# Set either to 1/true to start the proxy immediately and skip the menu.
+NON_INTERACTIVE=0
+SKIP_ACCOUNT_MENU=0
+
+# ── Chrome auth helper (scripts/deepseek_chrome_auth.js) ──
+# Path to a Chrome / Chrome-for-Testing binary (auto-detected when empty).
+CHROME_PATH=
+# Remote-debugging port for the auth browser (auto when empty).
+DEEPSEEK_CHROME_PORT=
+# Chrome profile directory (defaults to a temporary profile).
+DEEPSEEK_CHROME_PROFILE=
+# Keep the Chrome profile between runs (1/true).
+DEEPSEEK_KEEP_CHROME_PROFILE=0
+# Reuse an already-running Chrome instance (1/true).
+DEEPSEEK_REUSE_CHROME=0
+
+# ── Misc ──
+# Pre-set a token for non-interactive auth import.
+# DEEPSEEK_TOKEN=
+# Run scripts/doctor.js without network checks (1/true).
+# DOCTOR_OFFLINE=0


### PR DESCRIPTION
## Summary
Adds a `.env.example` (there wasn't one) documenting the supported environment variables with their code defaults:

- **Server:** `PORT` (9655), `HOST` (0.0.0.0)
- **Auth source:** `DEEPSEEK_AUTH_PATH` / `DEEPSEEK_AUTH_DIR`
- **Pool:** `DEEPSEEK_ACCOUNT_COOLDOWN_MS` (600000)
- **Startup:** `NON_INTERACTIVE`, `SKIP_ACCOUNT_MENU`
- **Chrome auth helper:** `CHROME_PATH`, `DEEPSEEK_CHROME_PORT`, `DEEPSEEK_CHROME_PROFILE`, `DEEPSEEK_KEEP_CHROME_PROFILE`, `DEEPSEEK_REUSE_CHROME`
- **Misc:** `DEEPSEEK_TOKEN`, `DOCTOR_OFFLINE`

A real `.env` stays gitignored.
