### PR TITLE
fix: parse DeepSeek search fragments without 502

### DIFF
--- a/server.js
+++ b/server.js
@@ -187,7 +187,9 @@ async function readDeepSeekJsonResponse(resp, label, account) {
     if (!resp.ok) markAccountFailure(account, resp.status, label);
     return { json, text };
 }
-loadDeepSeekConfig({ fatal: false });
+if (require.main === module) {
+    loadDeepSeekConfig({ fatal: false });
+}
 
 function createSession() {
     return {
@@ -328,6 +330,47 @@ const ALL_MODEL_CAPABILITIES = Object.fromEntries(Object.entries(MODEL_CONFIGS).
     supported: cfg.supported,
     unavailable_reason: cfg.unavailable_reason || null,
 }]));
+
+function isAssistantOutputFragment(fragment) {
+    return fragment
+        && (fragment.type === 'RESPONSE' || fragment.type === 'SEARCH')
+        && typeof fragment.content === 'string';
+}
+
+function isReasoningFragment(fragment) {
+    return fragment
+        && (fragment.type === 'THINK' || fragment.type === 'REASONING')
+        && typeof fragment.content === 'string';
+}
+
+function isDeepSeekModelErrorEvent(event) {
+    return event && event.type === 'error';
+}
+
+function rebuildFragmentText(fragments) {
+    const responseText = fragments
+        .filter(isAssistantOutputFragment)
+        .map(f => f.content)
+        .join('');
+    const thinkText = fragments
+        .filter(isReasoningFragment)
+        .map(f => f.content)
+        .join('');
+    return { responseText, thinkText };
+}
+
+function applyResponsePatchOperations(ops, appendFragments) {
+    if (!Array.isArray(ops)) return false;
+    let applied = false;
+    for (const op of ops) {
+        if (!op || typeof op !== 'object') continue;
+        if (op.p === 'fragments' && op.o === 'APPEND' && op.v !== undefined) {
+            appendFragments(op.v);
+            applied = true;
+        }
+    }
+    return applied;
+}
 
 function resolveModelConfig(model) {
     const requested = String(model || 'deepseek-chat').toLowerCase();
@@ -1204,15 +1247,8 @@ const server = http.createServer(async (req, res) => {
                 let finishReason = null;
                 let modelError = null;
 
-                const rebuildFragmentText = () => {
-                    const responseText = fragments
-                        .filter(f => f && f.type === 'RESPONSE' && typeof f.content === 'string')
-                        .map(f => f.content)
-                        .join('');
-                    const thinkText = fragments
-                        .filter(f => f && (f.type === 'THINK' || f.type === 'REASONING') && typeof f.content === 'string')
-                        .map(f => f.content)
-                        .join('');
+                const rebuildFragmentState = () => {
+                    const { responseText, thinkText } = rebuildFragmentText(fragments);
                     if (responseText) fullContent = responseText;
                     reasoningContent = thinkText;
                 };
@@ -1222,7 +1258,7 @@ const server = http.createServer(async (req, res) => {
                     for (const fragment of incoming) {
                         if (fragment && typeof fragment === 'object') fragments.push({ ...fragment });
                     }
-                    rebuildFragmentText();
+                    rebuildFragmentState();
                 };
 
                 for await (const chunk of readable) {
@@ -1234,9 +1270,11 @@ const server = http.createServer(async (req, res) => {
                             try {
                                 const d = JSON.parse(line.slice(6));
                                 if (d.response_message_id !== undefined && !newMessageId) newMessageId = d.response_message_id;
-                                if (d.type === 'error' || d.finish_reason || d.content) {
+                                if (isDeepSeekModelErrorEvent(d)) {
                                     modelError = { type: d.type || 'error', content: d.content || '', finish_reason: d.finish_reason || null };
-                                    if (d.finish_reason) finishReason = d.finish_reason;
+                                }
+                                if (d.finish_reason) {
+                                    finishReason = d.finish_reason;
                                 }
                                 if (d.p !== undefined) lastPath = d.p;
                                 if (d.v && typeof d.v === 'object' && d.v.response) {
@@ -1257,11 +1295,14 @@ const server = http.createServer(async (req, res) => {
                                 if (lastPath === 'response/fragments' && d.v !== undefined) {
                                     appendFragments(d.v);
                                 }
+                                if (lastPath === 'response' && d.v !== undefined) {
+                                    applyResponsePatchOperations(d.v, appendFragments);
+                                }
                                 if (lastPath === 'response/fragments/-1/content' && d.v !== undefined && typeof d.v !== 'object') {
                                     if (fragments.length > 0) {
                                         const lastFragment = fragments[fragments.length - 1];
                                         lastFragment.content = `${lastFragment.content || ''}${d.v}`;
-                                        rebuildFragmentText();
+                                        rebuildFragmentState();
                                     }
                                 }
                                 if (lastPath === 'response/content' && d.v !== undefined && typeof d.v !== 'object') {
@@ -1506,4 +1547,16 @@ async function main() {
     });
 }
 
-main().catch(err => { console.error('[DS-API] FATAL:', err); process.exit(1); });
+if (require.main === module) {
+    main().catch(err => { console.error('[DS-API] FATAL:', err); process.exit(1); });
+}
+
+module.exports = {
+    __test: {
+        isAssistantOutputFragment,
+        isReasoningFragment,
+        isDeepSeekModelErrorEvent,
+        rebuildFragmentText,
+        applyResponsePatchOperations,
+    },
+};

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const ROOT = path.resolve(__dirname, '..');
+const serverInternals = require('../server.js').__test;
 
 function tmpdir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'fdsapi-test-'));
@@ -108,4 +109,37 @@ test('chrome auth prints actionable OS instructions when Chrome is missing', () 
   assert.match(out, /macOS/i);
   assert.match(out, /Linux/i);
   assert.match(out, /CHROME_PATH/i);
+});
+
+test('DeepSeek stream parser treats SEARCH fragments as assistant output', () => {
+  const rebuilt = serverInternals.rebuildFragmentText([
+    { type: 'SEARCH', content: 'The official Reuters website is ' },
+    { type: 'SEARCH', content: 'https://www.reuters.com/.' },
+  ]);
+
+  assert.equal(rebuilt.responseText, 'The official Reuters website is https://www.reuters.com/.');
+  assert.equal(rebuilt.thinkText, '');
+});
+
+test('DeepSeek stream parser applies response-level fragment append patches', () => {
+  const fragments = [];
+  const appendFragments = (value) => {
+    const incoming = Array.isArray(value) ? value : [value];
+    for (const fragment of incoming) fragments.push({ ...fragment });
+  };
+
+  const applied = serverInternals.applyResponsePatchOperations([
+    { p: 'fragments', o: 'APPEND', v: [{ type: 'RESPONSE', content: 'The' }] },
+    { p: 'has_pending_fragment', o: 'SET', v: false },
+  ], appendFragments);
+
+  assert.equal(applied, true);
+  assert.deepEqual(fragments, [{ type: 'RESPONSE', content: 'The' }]);
+  assert.equal(serverInternals.rebuildFragmentText(fragments).responseText, 'The');
+});
+
+test('DeepSeek stream parser does not treat service content chunks as model errors', () => {
+  assert.equal(serverInternals.isDeepSeekModelErrorEvent({ content: 'Official Reuters website URL' }), false);
+  assert.equal(serverInternals.isDeepSeekModelErrorEvent({ finish_reason: 'stop' }), false);
+  assert.equal(serverInternals.isDeepSeekModelErrorEvent({ type: 'error', content: 'backend error' }), true);
 });


### PR DESCRIPTION
## Что случилось

Мы проверяли `FreeDeepseekAPI` как локальный public-only proxy для DeepSeek Web
Chat и наткнулись на стабильную проблему с `deepseek-chat-search`.

Обычный `deepseek-chat` работал, `deepseek-reasoner-search` тоже работал, но
`deepseek-chat-search` на публичных EN/RU search prompt'ах возвращал HTTP 502.
В body ошибки при этом лежала не техническая ошибка DeepSeek, а поисковая фраза
вроде:

- `Official Reuters website URL`
- `Официальный сайт Reuters`

То есть DeepSeek Web отвечал, но proxy неправильно разбирал stream.

## Как воспроизводилось

Сервер запускался локально:

```bash
HOST=127.0.0.1 PORT=9655 NON_INTERACTIVE=1 npm start
```

Публичный EN prompt:

```bash
curl -X POST http://127.0.0.1:9655/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "deepseek-chat-search",
    "stream": false,
    "messages": [
      {
        "role": "user",
        "content": "Search the web. What is the official Reuters website URL? Answer in one sentence and include the URL."
      }
    ]
  }'
```

Публичный RU prompt:

```bash
curl -X POST http://127.0.0.1:9655/v1/chat/completions \
  -H "Content-Type: application/json; charset=utf-8" \
  -d '{
    "model": "deepseek-chat-search",
    "stream": false,
    "messages": [
      {
        "role": "user",
        "content": "Найди официальный сайт Reuters и дай URL. Ответь по-русски."
      }
    ]
  }'
```

До фикса оба запроса могли завершаться 502.

## Причина

У DeepSeek Web search stream отличается от обычного chat stream:

1. Часть ответа приходит как fragment с `type: "SEARCH"`.
2. Первый кусок ответа может прийти не через `response/fragments/-1/content`,
   а как response-level patch:

```json
{
  "p": "response",
  "v": [
    {
      "p": "fragments",
      "o": "APPEND",
      "v": [
        {
          "type": "RESPONSE",
          "content": "The"
        }
      ]
    }
  ]
}
```

Старый parser:

- собирал в финальный ответ только fragments с `type: "RESPONSE"`;
- игнорировал content внутри `SEARCH` fragments;
- не применял response-level `fragments APPEND` patch;
- считал любой top-level `content` в stream событии ошибкой модели.

Из-за этого `fullContent` оставался пустым, а служебная search-фраза попадала в
`modelError`, после чего proxy возвращал 502.

## Что исправлено

В этом patch:

- `SEARCH` fragments считаются assistant output наравне с `RESPONSE`;
- model error создаётся только для события `type: "error"`;
- response-level patch operations `p: "fragments"`, `o: "APPEND"` применяются к
  списку fragments;
- добавлены unit tests на эти случаи;
- `server.js` больше не читает auth config при `require('../server.js')` из
  тестов, поэтому unit tests не шумят auth warning'ом.

## Проверка

`npm test`:

```text
tests 9
pass 9
fail 0
```

Live smoke после фикса:

- `deepseek-chat-search`, EN prompt: HTTP 200, ответ начинается с
  `The official Reuters website URL is ...`
- `deepseek-chat-search`, RU prompt: HTTP 200, ответ начинается с
  `Официальный сайт...`
- `deepseek-chat`: HTTP 200
- `deepseek-reasoner-search`: HTTP 200
- tool parser smoke: HTTP 200, вернул `tool_calls`
- Anthropic Messages shim: HTTP 200
- OpenAI Responses shim: HTTP 200

Важно: auth/token/cookie значения в отчёт не включались; проверялись только
публичные prompts.
