### PR TITLE
Корректность ответов: честный finish_reason + точный usage.prompt_tokens

### DIFF
--- a/server.js
+++ b/server.js
@@ -722,7 +722,7 @@ function buildToolCallResponse(toolCall, model = 'deepseek-default', prompt = ''
     };
 }
 
-function buildTextResponse(content, prompt, model = 'deepseek-default', reasoningContent = '') {
+function buildTextResponse(content, prompt, model = 'deepseek-default', reasoningContent = '', finishReason = null) {
     const message = { role: 'assistant', content };
     if (reasoningContent) message.reasoning_content = reasoningContent;
     return {
@@ -733,7 +733,9 @@ function buildTextResponse(content, prompt, model = 'deepseek-default', reasonin
         choices: [{
             index: 0,
             message,
-            finish_reason: 'stop'
+            // Surface truncation: a 'length' finish lets length-aware clients re-request
+            // instead of silently treating a cut-off answer as a clean stop.
+            finish_reason: finishReason === 'length' ? 'length' : 'stop'
         }],
         usage: buildUsage(prompt, content, reasoningContent),
         watermark: FORGETMEAI_WATERMARK
@@ -1266,6 +1268,10 @@ const server = http.createServer(async (req, res) => {
             }
 
             const { prompt, systemPrompt } = formatMessages(messages, tools);
+            // For usage accounting, count the CLIENT's original input — not the
+            // proxy-expanded fullPrompt (system + injected tools + history) — so
+            // prompt_tokens reflects what the caller actually sent.
+            const clientPromptText = messages.map(m => normalizeMessageContent(m.content)).join('\n');
 
             const session = getOrCreateAgentSession(agentId);
 
@@ -1502,8 +1508,8 @@ const server = http.createServer(async (req, res) => {
             storeHistory(agentId, prompt, fullContent, toolCall);
 
             const openaiResponse = toolCall
-                ? buildToolCallResponse(toolCall, requestedModel, fullPrompt, reasoningContent)
-                : buildTextResponse(fullContent, fullPrompt, requestedModel, reasoningContent);
+                ? buildToolCallResponse(toolCall, requestedModel, clientPromptText, reasoningContent)
+                : buildTextResponse(fullContent, clientPromptText, requestedModel, reasoningContent, finishReason);
 
             if (stream) {
                 if (apiMode === 'anthropic') {


### PR DESCRIPTION
Две небольшие правки корректности OpenAI-совместимого ответа.

## Что и зачем
- **`finish_reason` отражает реальный финиш DeepSeek.** Сейчас в ответе всегда
  `'stop'`, даже если ответ обрезан по длине. Сервер уже отслеживает `finishReason`
  (и даже использует его для авто-продолжения), но в тело ответа он не попадал.
  Клиенты, которые до-запрашивают по `finish_reason==='length'` (agent-лупы,
  Codex-style), молча получали усечённый ответ. Теперь усечение помечается `'length'`.
- **`usage.prompt_tokens` считается по исходным сообщениям клиента**, а не по
  раздутому `fullPrompt` (system-промпт + инжект описаний tools + история). Любой,
  кто меряет токены/биллинг по `usage`, получал цифры, не совпадающие с тем, что он
  реально отправил. Эвристика оценки (длина/4) не меняется — правится только источник текста.

## Проверено
`npm test` зелёный. Изменения точечные, в билдере ответа.
