### PR TITLE
fix: harden agent recovery and tool-call parsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ HOST=127.0.0.1
 # Optional bearer token required by every non-health endpoint. Strongly
 # recommended whenever HOST is not a loopback address.
 # PROXY_API_KEY=replace-with-a-long-random-value
+# Browser requests are accepted from loopback origins. Add exact remote UI
+# origins as a comma-separated allowlist when needed.
+# PROXY_CORS_ORIGINS=https://ui.example.com,http://192.168.1.20:3000
 
 # ── Account auth source ──
 # The pool loads DeepSeek accounts from files. Use either a single file or a

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,11 @@
 
 # ── HTTP server ──
 PORT=9655
-HOST=0.0.0.0
+# Loopback-only by default. Use 0.0.0.0 only when remote access is intentional.
+HOST=127.0.0.1
+# Optional bearer token required by every non-health endpoint. Strongly
+# recommended whenever HOST is not a loopback address.
+# PROXY_API_KEY=replace-with-a-long-random-value
 
 # ── Account auth source ──
 # The pool loads DeepSeek accounts from files. Use either a single file or a

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ DEEPSEEK_AUTH_PATH=./deepseek-auth.json
 # (default: 600000 = 10 minutes).
 DEEPSEEK_ACCOUNT_COOLDOWN_MS=600000
 
+# ── Long agent sessions ──
+# Maximum characters sent to DeepSeek Web after compacting old context.
+# Lower this if the Web endpoint reports that the content is too long.
+DEEPSEEK_MAX_PROMPT_CHARS=80000
+# Fresh-session retries for an empty/context-too-long response (default: 2).
+DEEPSEEK_MAX_RETRIES=2
+
 # ── Startup (deploy / CI) ──
 # Set either to 1/true to start the proxy immediately and skip the menu.
 NON_INTERACTIVE=0

--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ SKIP_ACCOUNT_MENU=1 npm start
 http://localhost:9655
 ```
 
+По умолчанию proxy доступен только с этого компьютера. Для доступа из сети
+явно задайте адрес и отдельный ключ proxy:
+
+```bash
+HOST=0.0.0.0 PROXY_API_KEY='replace-with-a-long-random-value' npm start
+```
+
+После этого передавайте ключ как `Authorization: Bearer <key>`. Без
+`PROXY_API_KEY` non-health endpoints остаются без авторизации, поэтому не
+публикуйте такой экземпляр в сеть.
+
 ---
 
 ## 🪟 Windows запуск
@@ -502,7 +513,9 @@ http://host.docker.internal:9655/v1
 http://localhost:9655/v1
 ```
 
-API key можно указать любой: proxy сам ходит в DeepSeek Web через сохранённую browser-сессию.
+Если `PROXY_API_KEY` не задан, API key можно указать любой. Если ключ задан,
+клиент должен передавать именно его — proxy проверяет bearer token перед
+доступом к моделям, сессиям и completions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ HOST=0.0.0.0 PROXY_API_KEY='replace-with-a-long-random-value' npm start
 `PROXY_API_KEY` non-health endpoints остаются без авторизации, поэтому не
 публикуйте такой экземпляр в сеть.
 
+Browser-запросы разрешены с loopback-origin. Если UI открыт на другом адресе,
+добавьте его точный origin через запятую, например
+`PROXY_CORS_ORIGINS=https://ui.example.com,http://192.168.1.20:3000`.
+
 ---
 
 ## 🪟 Windows запуск

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ FreeDeepseekAPI принимает:
 Прокси просит DeepSeek вернуть строгий JSON tool call, но также умеет парсить fallback-форматы:
 
 - `TOOL_CALL:`
-- fenced JSON
+- fenced JSON with an explicit `tool_call`, `tool_calls`, or `function_call` envelope
 - `<tool_call>...</tool_call>`
 - DeepSeek DSML (`<｜DSML｜tool_calls>...`) и Web-вариант с `<｜｜DSML｜｜ Tool Calls>`
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ FreeDeepseekAPI не создаёт новый DeepSeek чат на каждый
 - если session id уже есть — proxy переиспользует его и продолжает chain через `parent_message_id`;
 - auto-reset происходит при TTL, ошибке DeepSeek session или слишком длинной цепочке сообщений;
 - локальная history сохраняется коротким контекстом, чтобы новая DeepSeek session могла продолжить разговор.
+- длинные agent-запросы перед отправкой ограничиваются `DEEPSEEK_MAX_PROMPT_CHARS` (по умолчанию 80 000 символов): сохраняются начало задачи, свежие tool results и tool adapter;
+- если клиент уже прислал multi-turn history, локальная recovery-history второй раз не добавляется;
+- пустой ответ повторяется максимум `DEEPSEEK_MAX_RETRIES` раз (по умолчанию 2), причём на каждом retry контекст уменьшается.
 
 Явно задать agent/session:
 
@@ -442,6 +445,7 @@ FreeDeepseekAPI принимает:
 - `TOOL_CALL:`
 - fenced JSON
 - `<tool_call>...</tool_call>`
+- DeepSeek DSML (`<｜DSML｜tool_calls>...`) и Web-вариант с `<｜｜DSML｜｜ Tool Calls>`
 
 ---
 

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -16,12 +16,6 @@
     "service_worker": "background.js"
   },
   "action": {
-    "default_popup": "popup.html",
-    "default_icon": {
-      "48": "icon.png"
-    }
-  },
-  "icons": {
-    "48": "icon.png"
+    "default_popup": "popup.html"
   }
 }

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -359,7 +359,7 @@ DeepSeek Web does not expose native OpenAI tool calls, so the proxy prompt-emula
 
 - strict JSON: `{"tool_call":{"name":"tool","arguments":{...}}}`
 - legacy format: `TOOL_CALL: tool\narguments: {...}`
-- fenced JSON blocks
+- fenced JSON blocks with an explicit `tool_call`, `tool_calls`, or `function_call` envelope
 - XML-ish `<tool_call>{...}</tool_call>` wrappers
 - DeepSeek DSML (`<｜DSML｜tool_calls>...`) and the doubled-bar Web variant
 
@@ -440,8 +440,8 @@ The proxy uses `user` from the request body. If not set, it falls back to the cl
   id: "uuid",                    // DeepSeek web session ID
   parentMessageId: <int|null>,   // Last message ID for threading
   createdAt: <timestamp>,        // Session creation time
-  messageCount: 0-50,            // Messages in this session
-  history: [                     // Last 5 exchanges for context recovery
+  messageCount: 0-100,           // Messages in this session
+  history: [                     // Last 15 exchanges for context recovery
     { user: "...", assistant: "..." }
   ]
 }

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -361,6 +361,7 @@ DeepSeek Web does not expose native OpenAI tool calls, so the proxy prompt-emula
 - legacy format: `TOOL_CALL: tool\narguments: {...}`
 - fenced JSON blocks
 - XML-ish `<tool_call>{...}</tool_call>` wrappers
+- DeepSeek DSML (`<｜DSML｜tool_calls>...`) and the doubled-bar Web variant
 
 ### 3.7 List Active Sessions
 
@@ -514,14 +515,15 @@ The parser traverses character by character tracking brace depth:
 
 | Condition | Action |
 |---|---|
-| Message count >= 50 | Auto-reset DeepSeek session, keep history buffer |
+| Message count >= 100 | Auto-reset DeepSeek session, keep history buffer |
 | Session age > 2 hours | Auto-reset (DeepSeek web session TTL) |
 | HTTP 400/404/500 response | Reset and retry once |
-| Empty content response | Return HTTP 502 (no retry) |
+| Empty content response | Compact context, reset session, retry up to `DEEPSEEK_MAX_RETRIES` (default 2) |
+| Context/content too long | Pre-compact to `DEEPSEEK_MAX_PROMPT_CHARS`, then retry with a smaller budget |
 
 ### 6.2 History Buffer
 
-When a session is reset, the proxy preserves the **last 5 exchanges** (capped at ~3000 chars). On the next request, it injects them as context:
+When a session is reset, the proxy preserves the **last 15 exchanges** (capped at 10,000 chars). It injects this recovery context only when the client did not already send multi-turn history:
 
 ```
 [Previous conversation]
@@ -553,9 +555,10 @@ If DeepSeek's web session expires (HTTP 400/404/500):
 ### 7.1 Proxy Configuration (in deepseek-api-server.js)
 
 ```javascript
-const MAX_HISTORY_LENGTH = 5;     // Keep last 5 exchanges
-const MAX_HISTORY_CHARS = 3000;   // Max chars for history buffer
-const MAX_MESSAGE_DEPTH = 50;     // Auto-reset after 50 messages
+const MAX_HISTORY_LENGTH = 15;    // Keep last 15 exchanges
+const MAX_HISTORY_CHARS = 10000;  // Max chars for history buffer
+const MAX_MESSAGE_DEPTH = 100;    // Auto-reset after 100 messages
+const MAX_UPSTREAM_PROMPT_CHARS = 80000; // Configurable via DEEPSEEK_MAX_PROMPT_CHARS
 const SESSION_TTL_MS = 2 * 60 * 60 * 1000;  // 2 hours
 
 const DS_CONFIG = {

--- a/server.js
+++ b/server.js
@@ -219,15 +219,10 @@ function selectAccountForSession(session) {
     if (session.accountId) {
         const sticky = accounts.find(a => a.id === session.accountId);
         if (sticky && sticky.config.token && sticky.config.cookie && sticky.cooldownUntil <= now) return sticky;
-        if (sticky && sticky.cooldownUntil > now) {
-            // A DeepSeek chat_session belongs to the auth account that created it.
-            // If that account is rate-limited/expired, do not keep hammering it;
-            // reset the web session and let a healthy account take over.
-            session.id = null;
-            session.parentMessageId = null;
-            session.createdAt = null;
-            session.messageCount = 0;
-        }
+        // A DeepSeek chat_session belongs to the auth account that created it.
+        // If that account disappeared, lost credentials, or is cooling down,
+        // never reuse its session id under a different account.
+        resetRemoteSession(session);
         session.accountId = null;
     }
     const ready = accounts.filter(a => a.config.token && a.config.cookie && a.cooldownUntil <= now);
@@ -513,6 +508,7 @@ function isSupportedModel(model) { return resolveModelConfig(model).supported ==
 async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default', freshSessionPrompt = prompt) {
     const modelCfg = resolveModelConfig(model);
     const session = getOrCreateAgentSession(agentId);
+    const hadRemoteSession = Boolean(session.id);
     const account = selectAccountForSession(session);
     const dsHeaders = account.headers;
     account.lastUsedAt = Date.now();
@@ -522,7 +518,12 @@ async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default', fr
     // recovery history can be injected. Keep this guard for direct callers and
     // concurrent requests that may have advanced the same session meanwhile.
     const rollover = prepareSessionForPrompt(session);
-    let effectivePrompt = rollover ? freshSessionPrompt : prompt;
+    const accountRotationReset = hadRemoteSession && !session.id;
+    const recoveredFreshSession = accountRotationReset || Boolean(rollover);
+    let effectivePrompt = recoveredFreshSession ? freshSessionPrompt : prompt;
+    if (accountRotationReset) {
+        console.log(`${agentTag} Account rotation reset the previous remote session; using recovery prompt.`);
+    }
     if (rollover) {
         console.log(`${agentTag} Session ${rollover.failedSessionId} reset before upstream call (${rollover.reason}).`);
     }
@@ -639,7 +640,7 @@ async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default', fr
         throw createUpstreamHttpError(resp.status, errText, retryAfter);
     }
 
-    return { resp, agentId, account, promptUsed: effectivePrompt, freshSessionReset: Boolean(rollover) };
+    return { resp, agentId, account, promptUsed: effectivePrompt, freshSessionReset: recoveredFreshSession };
 }
 
 // === Tool Calling Support ===
@@ -1654,6 +1655,14 @@ function appendPromptInstruction(promptText, instruction, maxChars = MAX_UPSTREA
     return truncatePromptMiddle(promptText, baseBudget, 0.35) + suffix;
 }
 
+function isContinuationRecoverySafe(previousAccountId, continuationCall) {
+    const nextAccountId = continuationCall?.account?.id;
+    return !previousAccountId
+        || !nextAccountId
+        || nextAccountId === previousAccountId
+        || continuationCall?.freshSessionReset === true;
+}
+
 function isContextTooLongError(error) {
     const message = typeof error === 'string'
         ? error
@@ -2153,16 +2162,20 @@ const server = http.createServer(async (req, res) => {
                     `${freshPromptBuild.prompt}\n\n[Assistant response so far]\n${fullContent}`,
                     'Continue the assistant response from exactly where it stopped. Do not restart or repeat completed sections.'
                 );
-                const { resp: contResp, account: contAccount } = await askDeepSeekStream(
+                const continuationCall = await askDeepSeekStream(
                     'continue',
                     agentId,
                     requestedModel,
                     continuationRecoveryPrompt
                 );
-                // If rotation moved us to a different account, its chat_session has no
-                // prior context — "continue" would return irrelevant text. Abort (#20).
-                if (contAccount && contBeforeId && contAccount.id !== contBeforeId) {
+                const { resp: contResp, account: contAccount } = continuationCall;
+                // A cross-account continuation is valid only when the call
+                // detected that reset and sent the full recovery prompt. If an
+                // unexpected rotation ever bypasses that guard, discard the new
+                // remote session before returning to the client (#20).
+                if (!isContinuationRecoverySafe(contBeforeId, continuationCall)) {
                     console.log(`${agentTag} continuation rotated to ${contAccount.id} ≠ ${contBeforeId} — skipping (foreign session)`);
+                    resetRemoteSession(session);
                     break;
                 }
                 const contResult = await readDeepSeekResponse(contResp.body);
@@ -2412,6 +2425,7 @@ module.exports = {
         buildRecoveryHistoryPrefix,
         buildBoundedPrompt,
         buildRetryPrompt,
+        isContinuationRecoverySafe,
         isContextTooLongError,
         normalizeRetryResponse,
         classifyRecoveryFailure,
@@ -2422,6 +2436,8 @@ module.exports = {
         prepareSessionForPrompt,
         sweepIdleSessions,
         sessions,
+        accounts,
+        selectAccountForSession,
         isProxyAuthorized,
         isLoopbackHost,
         normalizeOrigin,

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@
  * parses LLM text responses for TOOL_CALL patterns, returns OpenAI tool_calls format.
  * 
  * Per-agent sessions: each unique `user` field gets its own DeepSeek web session.
- * Auto-reset: sessions reset when message chain > 50 messages or age > 2 hours.
+ * Auto-reset: sessions reset when message chain reaches 100 messages or age > 2 hours.
  * Listens on 127.0.0.1:9655 by default (HOST is configurable)
  */
 
@@ -465,6 +465,19 @@ function isDeepSeekModelErrorEvent(event) {
     return event && event.type === 'error';
 }
 
+function createUpstreamHttpError(status, body = '', retryAfter = null) {
+    const code = Number(status) || 502;
+    const detail = String(body || '').replace(/\s+/g, ' ').trim().substring(0, 300);
+    const type = code === 429
+        ? 'rate_limit_error'
+        : ((code === 401 || code === 403) ? 'authentication_error' : 'upstream_http_error');
+    const error = new Error(`DeepSeek upstream HTTP ${code}${detail ? `: ${detail}` : ''}`);
+    error.status = code;
+    error.type = type;
+    if (retryAfter) error.retryAfter = retryAfter;
+    return error;
+}
+
 function rebuildFragmentText(fragments) {
     const responseText = fragments
         .filter(isAssistantOutputFragment)
@@ -497,7 +510,7 @@ function resolveModelConfig(model) {
 function isKnownModel(model) { return Object.prototype.hasOwnProperty.call(MODEL_CONFIGS, String(model || '').toLowerCase()); }
 function isSupportedModel(model) { return resolveModelConfig(model).supported === true; }
 
-async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default') {
+async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default', freshSessionPrompt = prompt) {
     const modelCfg = resolveModelConfig(model);
     const session = getOrCreateAgentSession(agentId);
     const account = selectAccountForSession(session);
@@ -509,6 +522,7 @@ async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default') {
     // recovery history can be injected. Keep this guard for direct callers and
     // concurrent requests that may have advanced the same session meanwhile.
     const rollover = prepareSessionForPrompt(session);
+    let effectivePrompt = rollover ? freshSessionPrompt : prompt;
     if (rollover) {
         console.log(`${agentTag} Session ${rollover.failedSessionId} reset before upstream call (${rollover.reason}).`);
     }
@@ -562,7 +576,7 @@ async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default') {
             chat_session_id: session.id,
             parent_message_id: session.parentMessageId,
             model_type: modelCfg.model_type,
-            prompt: prompt, ref_file_ids: [],
+            prompt: effectivePrompt, ref_file_ids: [],
             thinking_enabled: modelCfg.thinking_enabled, search_enabled: modelCfg.search_enabled,
             action: null, preempt: false,
         })
@@ -571,7 +585,8 @@ async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default') {
     // If session expired, reset and retry once
     if (resp.status !== 200) {
         // Pass Retry-After so a 429 honors the server-requested cooldown (#16).
-        markAccountFailure(account, resp.status, 'completion', resp.headers.get('retry-after'));
+        const retryAfter = resp.headers.get('retry-after');
+        markAccountFailure(account, resp.status, 'completion', retryAfter);
         const errText = await resp.text();
         console.log(`${agentTag} Session error (${resp.status}): ${errText.substring(0, 100)}`);
         if (resp.status === 400 || resp.status === 404 || resp.status === 500) {
@@ -604,35 +619,64 @@ async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default') {
                     chat_session_id: session.id,
                     parent_message_id: null,
                     model_type: modelCfg.model_type,
-                    prompt: prompt, ref_file_ids: [],
+                    prompt: freshSessionPrompt, ref_file_ids: [],
                     thinking_enabled: modelCfg.thinking_enabled, search_enabled: modelCfg.search_enabled,
                     action: null, preempt: false,
                 })
             });
-            return { resp: resp2, agentId, account };
+            if (!resp2.ok) {
+                const retryAfter2 = resp2.headers.get('retry-after');
+                markAccountFailure(account, resp2.status, 'completion after session recreate', retryAfter2);
+                const errText2 = await resp2.text();
+                throw createUpstreamHttpError(resp2.status, errText2, retryAfter2);
+            }
+            effectivePrompt = freshSessionPrompt;
+            return { resp: resp2, agentId, account, promptUsed: effectivePrompt, freshSessionReset: true };
         }
+        // The body was consumed for diagnostics, so returning this Response
+        // would hand a locked stream to readDeepSeekResponse. Surface a typed
+        // error instead and retain the real upstream status/Retry-After.
+        throw createUpstreamHttpError(resp.status, errText, retryAfter);
     }
 
-    return { resp, agentId, account };
+    return { resp, agentId, account, promptUsed: effectivePrompt, freshSessionReset: Boolean(rollover) };
 }
 
 // === Tool Calling Support ===
 
 const TOOL_SCHEMA_ANNOTATION_KEYS = new Set(['description', 'examples', '$comment', 'title']);
 const TOOL_SCHEMA_MAP_KEYS = new Set(['properties', 'patternProperties', '$defs', 'definitions', 'dependentSchemas']);
+const TOOL_SCHEMA_ARRAY_KEYS = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems']);
+const TOOL_SCHEMA_SINGLE_KEYS = new Set([
+    'additionalItems', 'additionalProperties', 'contains', 'contentSchema', 'else', 'if',
+    'items', 'not', 'propertyNames', 'then', 'unevaluatedItems', 'unevaluatedProperties',
+]);
 
-function compactToolSchema(value, preserveMapKeys = false) {
-    if (Array.isArray(value)) return value.map(child => compactToolSchema(child, false));
+function compactToolSchema(value) {
+    if (Array.isArray(value)) return value.map(compactToolSchema);
     if (!value || typeof value !== 'object') return value;
     const compact = {};
     for (const [key, child] of Object.entries(value)) {
         // Descriptions/examples dominate large agent tool payloads but do not
-        // affect argument validation. A schema can also legally define an
-        // argument *named* "description" or "title", so keys inside schema maps
-        // must not be mistaken for annotations.
-        if (!preserveMapKeys && TOOL_SCHEMA_ANNOTATION_KEYS.has(key)) continue;
-        const childIsSchemaMap = !preserveMapKeys && TOOL_SCHEMA_MAP_KEYS.has(key);
-        compact[key] = compactToolSchema(child, childIsSchemaMap);
+        // affect argument validation. Traverse only keywords whose values are
+        // themselves schemas. Literal instance values under const/enum/default
+        // must remain byte-for-byte equivalent, even when they contain fields
+        // named "description" or "title".
+        if (TOOL_SCHEMA_ANNOTATION_KEYS.has(key)) continue;
+        if (TOOL_SCHEMA_MAP_KEYS.has(key) && child && typeof child === 'object' && !Array.isArray(child)) {
+            compact[key] = Object.fromEntries(Object.entries(child).map(([name, schema]) => [name, compactToolSchema(schema)]));
+        } else if (TOOL_SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(child)) {
+            compact[key] = child.map(compactToolSchema);
+        } else if (TOOL_SCHEMA_SINGLE_KEYS.has(key)) {
+            compact[key] = Array.isArray(child) ? child.map(compactToolSchema) : compactToolSchema(child);
+        } else if (key === 'dependencies' && child && typeof child === 'object' && !Array.isArray(child)) {
+            compact[key] = Object.fromEntries(Object.entries(child).map(([name, dependency]) => [
+                name,
+                Array.isArray(dependency) ? dependency : compactToolSchema(dependency),
+            ]));
+        } else {
+            compact[key] = child;
+        }
     }
     return compact;
 }
@@ -1225,7 +1269,7 @@ function writeSse(res, event, data) {
 }
 
 function sendAnthropicStream(res, openaiResp) {
-    res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive', 'Access-Control-Allow-Origin': '*' });
+    res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive' });
     const choice = openaiResp.choices[0];
     const msg = choice.message || {};
     const message = toAnthropicResponse(openaiResp);
@@ -1296,7 +1340,7 @@ function toResponsesResponse(openaiResp) {
 }
 
 function sendResponsesStream(res, openaiResp) {
-    res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive', 'Access-Control-Allow-Origin': '*' });
+    res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive' });
     const response = toResponsesResponse(openaiResp);
     const choice = openaiResp.choices[0];
     const msg = choice.message || {};
@@ -1338,7 +1382,7 @@ function sendResponsesStream(res, openaiResp) {
 }
 
 function sendOpenAIStream(res, openaiResp) {
-    res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive', 'Access-Control-Allow-Origin': '*' });
+    res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive' });
     const choice = openaiResp.choices[0];
     const msg = choice.message || {};
     const id = openaiResp.id;
@@ -1441,6 +1485,15 @@ function hasExplicitConversationHistory(messages) {
     return turns.length > 1 || turns.some(msg => msg.role === 'assistant' || msg.role === 'tool');
 }
 
+function buildRecoveryHistoryPrefix(history) {
+    if (!Array.isArray(history) || history.length === 0) return '';
+    let prefix = '[Previous conversation]\n';
+    for (const exchange of history) {
+        prefix += `User: ${String(exchange?.user || '')}\nAssistant: ${String(exchange?.assistant || '')}\n\n`;
+    }
+    return prefix + '[Continue from here]\n\n';
+}
+
 function buildBoundedPrompt(systemPrompt, historyPrefix, conversationPrompt, maxChars = MAX_UPSTREAM_PROMPT_CHARS) {
     const system = String(systemPrompt || '').trim();
     const history = String(historyPrefix || '');
@@ -1488,13 +1541,12 @@ function buildBoundedPrompt(systemPrompt, historyPrefix, conversationPrompt, max
 function buildRetryPrompt(systemPrompt, historyPrefix, conversationPrompt, currentPrompt, maxChars) {
     const retryBuild = buildBoundedPrompt(systemPrompt, historyPrefix, conversationPrompt, maxChars);
     const current = String(currentPrompt || '');
-    const prompt = retryBuild.prompt.length < current.length ? retryBuild.prompt : current;
     return {
-        prompt,
-        compacted: prompt.length < current.length,
-        historyDropped: prompt === retryBuild.prompt && retryBuild.historyDropped,
+        ...retryBuild,
+        compacted: retryBuild.compacted || retryBuild.prompt.length < current.length,
         originalChars: retryBuild.originalChars,
-        promptChars: prompt.length,
+        promptChars: retryBuild.prompt.length,
+        previousPromptChars: current.length,
     };
 }
 
@@ -1788,17 +1840,16 @@ const server = http.createServer(async (req, res) => {
                 console.log(`${agentTag} Session ${promptRollover.failedSessionId} reset before prompt build (${promptRollover.reason}); recovery history preserved.`);
             }
 
-            // Build history prefix if starting fresh
-            let historyPrefix = '';
-            if (!session.id && session.history.length > 0 && !hasExplicitConversationHistory(messages)) {
-                historyPrefix = '[Previous conversation]\n';
-                for (const exchange of session.history) {
-                    historyPrefix += `User: ${exchange.user}\nAssistant: ${exchange.assistant}\n\n`;
-                }
-                historyPrefix += '[Continue from here]\n\n';
-            }
+            // Keep a recovery prompt available even while the upstream session
+            // is healthy. If that remote chat expires mid-request, its opaque
+            // state disappears and the replacement must receive local history.
+            const recoveryHistoryPrefix = hasExplicitConversationHistory(messages)
+                ? ''
+                : buildRecoveryHistoryPrefix(session.history);
+            const historyPrefix = !session.id ? recoveryHistoryPrefix : '';
 
             const promptBuild = buildBoundedPrompt(systemPrompt, historyPrefix, prompt);
+            const freshPromptBuild = buildBoundedPrompt(systemPrompt, recoveryHistoryPrefix, prompt);
             let fullPrompt = promptBuild.prompt;
             let promptCompacted = promptBuild.compacted;
             if (promptBuild.compacted) {
@@ -1807,7 +1858,15 @@ const server = http.createServer(async (req, res) => {
             }
 
             const startTime = Date.now();
-            const { resp: dsResp } = await askDeepSeekStream(fullPrompt, agentId, requestedModel);
+            const initialCall = await askDeepSeekStream(fullPrompt, agentId, requestedModel, freshPromptBuild.prompt);
+            const dsResp = initialCall.resp;
+            if (initialCall.promptUsed !== fullPrompt) {
+                fullPrompt = initialCall.promptUsed;
+                if (freshPromptBuild.compacted) {
+                    promptCompacted = true;
+                    markContextCompacted(res);
+                }
+            }
 
             // Process streaming response from DeepSeek — returns { content, reasoningContent, messageId, finishReason }
             async function readDeepSeekResponse(readable) {
@@ -1926,7 +1985,7 @@ const server = http.createServer(async (req, res) => {
                     ? Math.max(0.35, 0.8 - retryAttempt * 0.2)
                     : Math.max(0.5, 1 - retryAttempt * 0.2);
                 const retryBudget = Math.max(MIN_UPSTREAM_PROMPT_CHARS, Math.floor(MAX_UPSTREAM_PROMPT_CHARS * retryRatio));
-                const retryBuild = buildRetryPrompt(systemPrompt, historyPrefix, prompt, fullPrompt, retryBudget);
+                const retryBuild = buildRetryPrompt(systemPrompt, recoveryHistoryPrefix, prompt, fullPrompt, retryBudget);
                 const retryPrompt = retryBuild.prompt;
                 if (retryBuild.compacted) {
                     promptCompacted = true;
@@ -1992,7 +2051,16 @@ const server = http.createServer(async (req, res) => {
                 console.log(`${agentTag} Response ${fullContent.length} chars (finish=${finishReason}). Auto-continuing (${continuationRounds}/${MAX_CONTINUATION})...`);
                 await new Promise(r => setTimeout(r, 500));
                 const contBeforeId = session.accountId;
-                const { resp: contResp, account: contAccount } = await askDeepSeekStream('continue', agentId, requestedModel);
+                const continuationRecoveryPrompt = appendPromptInstruction(
+                    `${freshPromptBuild.prompt}\n\n[Assistant response so far]\n${fullContent}`,
+                    'Continue the assistant response from exactly where it stopped. Do not restart or repeat completed sections.'
+                );
+                const { resp: contResp, account: contAccount } = await askDeepSeekStream(
+                    'continue',
+                    agentId,
+                    requestedModel,
+                    continuationRecoveryPrompt
+                );
                 // If rotation moved us to a different account, its chat_session has no
                 // prior context — "continue" would return irrelevant text. Abort (#20).
                 if (contAccount && contBeforeId && contAccount.id !== contBeforeId) {
@@ -2029,7 +2097,7 @@ const server = http.createServer(async (req, res) => {
                 resetRemoteSession(session);
                 await new Promise(r => setTimeout(r, 1000));
                 const strictPrompt = appendPromptInstruction(
-                    fullPrompt,
+                    freshPromptBuild.prompt,
                     '[STRICT INSTRUCTION] Your previous response contained incomplete tool-call markup. Keep arguments short and output ONLY strict JSON: {"tool_call":{"name":"<function>","arguments":{...}}}'
                 );
                 const { resp: retryResp2 } = await askDeepSeekStream(strictPrompt, agentId, requestedModel);
@@ -2233,6 +2301,7 @@ module.exports = {
         isAssistantOutputFragment,
         isReasoningFragment,
         isDeepSeekModelErrorEvent,
+        createUpstreamHttpError,
         rebuildFragmentText,
         applyResponsePatchOperations,
         compactToolSchema,
@@ -2242,6 +2311,7 @@ module.exports = {
         looksLikeToolCallMarkup,
         truncatePromptMiddle,
         hasExplicitConversationHistory,
+        buildRecoveryHistoryPrefix,
         buildBoundedPrompt,
         buildRetryPrompt,
         isContextTooLongError,
@@ -2261,5 +2331,8 @@ module.exports = {
         setCorsResponseHeaders,
         markContextCompacted,
         CONTEXT_COMPACTED_HEADER,
+        sendAnthropicStream,
+        sendResponsesStream,
+        sendOpenAIStream,
     },
 };

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@
  * 
  * Per-agent sessions: each unique `user` field gets its own DeepSeek web session.
  * Auto-reset: sessions reset when message chain > 50 messages or age > 2 hours.
- * Listens on 0.0.0.0:9655
+ * Listens on 127.0.0.1:9655 by default (HOST is configurable)
  */
 
 const http = require('http');
@@ -15,6 +15,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const readline = require('readline');
+const crypto = require('crypto');
 const { spawnSync } = require('child_process');
 const { solvePOW } = require('./lib/pow');
 
@@ -40,7 +41,8 @@ const SERVER_PUBLIC_IP = (() => {
 
 const FORGETMEAI_WATERMARK = 't.me/forgetmeai';
 const PORT = Number(process.env.PORT || 9655);
-const HOST = process.env.HOST || '0.0.0.0';
+const HOST = process.env.HOST || '127.0.0.1';
+const PROXY_API_KEY = String(process.env.PROXY_API_KEY || '');
 function formatWatermark(prefix = 'ForgetMeAI') { return `${prefix}: ${FORGETMEAI_WATERMARK}`; }
 function printBanner() {
     console.log(`
@@ -59,6 +61,18 @@ function prompt(question) {
     return new Promise(resolve => rl.question(question, ans => { rl.close(); resolve(ans); }));
 }
 function isTruthy(value) { return typeof value === 'string' && ['1','true','yes','on'].includes(value.trim().toLowerCase()); }
+
+function isProxyAuthorized(authorization, expectedKey = PROXY_API_KEY) {
+    if (!expectedKey) return true;
+    if (typeof authorization !== 'string' || !authorization.startsWith('Bearer ')) return false;
+    const supplied = Buffer.from(authorization.slice('Bearer '.length), 'utf8');
+    const expected = Buffer.from(String(expectedKey), 'utf8');
+    return supplied.length === expected.length && crypto.timingSafeEqual(supplied, expected);
+}
+
+function isLoopbackHost(host) {
+    return host === '127.0.0.1' || host === '::1' || host === 'localhost';
+}
 
 // === Per-Agent Session Store ===
 const sessions = new Map();  // keyed by agent ID (from `user` field)
@@ -1145,6 +1159,15 @@ const server = http.createServer(async (req, res) => {
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
 
     const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+    const isPublicProbe = req.method === 'GET' && (url.pathname === '/' || url.pathname === '/health' || url.pathname === '/readyz');
+    if (!isPublicProbe && !isProxyAuthorized(req.headers.authorization)) {
+        res.writeHead(401, {
+            'Content-Type': 'application/json',
+            'WWW-Authenticate': 'Bearer',
+        });
+        res.end(JSON.stringify({ error: { message: 'Invalid or missing proxy API key', type: 'authentication_error' } }));
+        return;
+    }
 
     // Health check
     if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/health')) {
@@ -1651,6 +1674,9 @@ async function showStartupMenu() {
 
 async function main() {
     printBanner();
+    if (!isLoopbackHost(HOST) && !PROXY_API_KEY) {
+        console.warn(`[DS-API] WARNING: HOST=${HOST} exposes the proxy without authentication. Set PROXY_API_KEY or bind to 127.0.0.1.`);
+    }
     const shouldStart = await showStartupMenu();
     if (!shouldStart) process.exit(0);
     server.on('error', (err) => {
@@ -1699,5 +1725,7 @@ module.exports = {
         createSession,
         sweepIdleSessions,
         sessions,
+        isProxyAuthorized,
+        isLoopbackHost,
     },
 };

--- a/server.js
+++ b/server.js
@@ -43,6 +43,10 @@ const FORGETMEAI_WATERMARK = 't.me/forgetmeai';
 const PORT = Number(process.env.PORT || 9655);
 const HOST = process.env.HOST || '127.0.0.1';
 const PROXY_API_KEY = String(process.env.PROXY_API_KEY || '');
+const PROXY_CORS_ORIGINS = new Set(String(process.env.PROXY_CORS_ORIGINS || '')
+    .split(',')
+    .map(value => normalizeOrigin(value))
+    .filter(Boolean));
 function formatWatermark(prefix = 'ForgetMeAI') { return `${prefix}: ${FORGETMEAI_WATERMARK}`; }
 function printBanner() {
     console.log(`
@@ -71,7 +75,35 @@ function isProxyAuthorized(authorization, expectedKey = PROXY_API_KEY) {
 }
 
 function isLoopbackHost(host) {
-    return host === '127.0.0.1' || host === '::1' || host === 'localhost';
+    const normalized = String(host || '').trim().toLowerCase().replace(/^\[|\]$/g, '');
+    return normalized === '127.0.0.1'
+        || normalized === '::1'
+        || normalized === '::ffff:127.0.0.1'
+        || normalized === 'localhost';
+}
+
+function normalizeOrigin(origin) {
+    const value = String(origin || '').trim().replace(/\/+$/, '');
+    if (!value) return '';
+    try {
+        const parsed = new URL(value);
+        return parsed.origin === 'null' ? value : parsed.origin;
+    } catch (e) {
+        return value;
+    }
+}
+
+function isBrowserOriginAllowed(origin, allowedOrigins = PROXY_CORS_ORIGINS) {
+    if (!origin) return true; // curl, SDKs, and other non-browser clients
+    const normalized = normalizeOrigin(origin);
+    if (allowedOrigins.has(normalized)) return true;
+    try {
+        const parsed = new URL(normalized);
+        return (parsed.protocol === 'http:' || parsed.protocol === 'https:')
+            && isLoopbackHost(parsed.hostname);
+    } catch (e) {
+        return false;
+    }
 }
 
 // === Per-Agent Session Store ===
@@ -1358,7 +1390,14 @@ function formatMessages(messages, tools) {
 
 // === HTTP Server ===
 const server = http.createServer(async (req, res) => {
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    const requestOrigin = req.headers.origin;
+    res.setHeader('Vary', 'Origin');
+    if (!isBrowserOriginAllowed(requestOrigin)) {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: { message: 'Browser origin is not allowed', type: 'cors_error' } }));
+        return;
+    }
+    if (requestOrigin) res.setHeader('Access-Control-Allow-Origin', normalizeOrigin(requestOrigin));
     res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
@@ -1376,8 +1415,19 @@ const server = http.createServer(async (req, res) => {
 
     // Health check
     if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/health')) {
+        const includePrivateStatus = !PROXY_API_KEY || isProxyAuthorized(req.headers.authorization);
+        const health = { status: 'ok', service: 'FreeDeepseekAPI', watermark: FORGETMEAI_WATERMARK };
+        if (includePrivateStatus) Object.assign(health, {
+            models: SUPPORTED_MODEL_IDS,
+            unsupported_models: Object.keys(MODEL_CONFIGS).filter(id => !MODEL_CONFIGS[id].supported),
+            agents: sessions.size,
+            in_flight: inFlight,
+            accounts: accounts.map(accountStatus),
+            config_ready: hasAuthConfig(),
+            session_reuse: { strategy: 'sticky per x-agent-session/user', ttl_minutes: Math.round(SESSION_TTL_MS / 60000), max_messages: MAX_MESSAGE_DEPTH, reset_all: 'POST /reset-session?agent=all' },
+        });
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ status: 'ok', service: 'FreeDeepseekAPI', watermark: FORGETMEAI_WATERMARK, models: SUPPORTED_MODEL_IDS, unsupported_models: Object.keys(MODEL_CONFIGS).filter(id => !MODEL_CONFIGS[id].supported), agents: sessions.size, in_flight: inFlight, accounts: accounts.map(accountStatus), config_ready: hasAuthConfig(), session_reuse: { strategy: 'sticky per x-agent-session/user', ttl_minutes: Math.round(SESSION_TTL_MS / 60000), max_messages: MAX_MESSAGE_DEPTH, reset_all: 'POST /reset-session?agent=all' } }));
+        res.end(JSON.stringify(health));
         return;
     }
 
@@ -1989,5 +2039,7 @@ module.exports = {
         sessions,
         isProxyAuthorized,
         isLoopbackHost,
+        normalizeOrigin,
+        isBrowserOriginAllowed,
     },
 };

--- a/server.js
+++ b/server.js
@@ -106,6 +106,16 @@ function isBrowserOriginAllowed(origin, allowedOrigins = PROXY_CORS_ORIGINS) {
     }
 }
 
+const CONTEXT_COMPACTED_HEADER = 'X-FreeDeepseek-Context-Compacted';
+function setCorsResponseHeaders(res) {
+    res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    res.setHeader('Access-Control-Expose-Headers', CONTEXT_COMPACTED_HEADER);
+}
+function markContextCompacted(res) {
+    res.setHeader(CONTEXT_COMPACTED_HEADER, 'true');
+}
+
 // === Per-Agent Session Store ===
 const sessions = new Map();  // keyed by agent ID (from `user` field)
 const MAX_HISTORY_LENGTH = 15;
@@ -292,6 +302,30 @@ function createSession() {
     };
 }
 
+function resetRemoteSession(session) {
+    const failed = {
+        failedSessionId: session.id,
+        failedMessageCount: session.messageCount,
+        accountId: session.accountId,
+    };
+    session.id = null;
+    session.parentMessageId = null;
+    session.createdAt = null;
+    session.messageCount = 0;
+    // Keep local recovery history and the sticky account assignment. A remote
+    // chat can be unhealthy without invalidating either of those local hints.
+    return failed;
+}
+
+function prepareSessionForPrompt(session, now = Date.now()) {
+    if (!session || !session.id) return null;
+    let reason = null;
+    if (session.messageCount >= MAX_MESSAGE_DEPTH) reason = 'max_message_depth';
+    else if (session.createdAt && now - session.createdAt > SESSION_TTL_MS) reason = 'session_ttl';
+    if (!reason) return null;
+    return { reason, ...resetRemoteSession(session) };
+}
+
 function getOrCreateAgentSession(agentId) {
     if (!sessions.has(agentId)) {
         sessions.set(agentId, createSession());
@@ -471,23 +505,12 @@ async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default') {
     account.lastUsedAt = Date.now();
     const agentTag = `[${agentId}/acct:${account.id}]`;
 
-    // Auto-reset on deep message chain
-    if (session.id && session.messageCount >= MAX_MESSAGE_DEPTH) {
-        console.log(`${agentTag} Session ${session.id} hit ${session.messageCount} messages. Auto-resetting.`);
-        session.id = null;
-        session.parentMessageId = null;
-        session.createdAt = null;
-        session.messageCount = 0;
-        // History preserved for context injection
-    }
-
-    // Reset expired sessions (DeepSeek web sessions last ~1-2 hours)
-    if (session.id && session.createdAt && (Date.now() - session.createdAt > SESSION_TTL_MS)) {
-        console.log(`${agentTag} Session ${session.id} expired (age: ${Math.round((Date.now() - session.createdAt) / 60000)}min). Creating new...`);
-        session.id = null;
-        session.parentMessageId = null;
-        session.createdAt = null;
-        session.messageCount = 0;
+    // Normally this rollover is performed before the prompt is built, so local
+    // recovery history can be injected. Keep this guard for direct callers and
+    // concurrent requests that may have advanced the same session meanwhile.
+    const rollover = prepareSessionForPrompt(session);
+    if (rollover) {
+        console.log(`${agentTag} Session ${rollover.failedSessionId} reset before upstream call (${rollover.reason}).`);
     }
 
     const cr = await dsFetch('https://chat.deepseek.com/api/v0/chat/create_pow_challenge', {
@@ -553,10 +576,7 @@ async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default') {
         console.log(`${agentTag} Session error (${resp.status}): ${errText.substring(0, 100)}`);
         if (resp.status === 400 || resp.status === 404 || resp.status === 500) {
             console.log(`${agentTag} Session ${session.id} expired. Creating new session...`);
-            session.id = null;
-            session.parentMessageId = null;
-            session.createdAt = null;
-            session.messageCount = 0;
+            resetRemoteSession(session);
 
             const sr2 = await dsFetch('https://chat.deepseek.com/api/v0/chat_session/create', {
                 method: 'POST', headers: dsHeaders, body: '{}'
@@ -598,15 +618,21 @@ async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default') {
 
 // === Tool Calling Support ===
 
-function compactToolSchema(value) {
-    if (Array.isArray(value)) return value.map(compactToolSchema);
+const TOOL_SCHEMA_ANNOTATION_KEYS = new Set(['description', 'examples', '$comment', 'title']);
+const TOOL_SCHEMA_MAP_KEYS = new Set(['properties', 'patternProperties', '$defs', 'definitions', 'dependentSchemas']);
+
+function compactToolSchema(value, preserveMapKeys = false) {
+    if (Array.isArray(value)) return value.map(child => compactToolSchema(child, false));
     if (!value || typeof value !== 'object') return value;
     const compact = {};
     for (const [key, child] of Object.entries(value)) {
         // Descriptions/examples dominate large agent tool payloads but do not
-        // affect argument validation. Keep the structural schema intact.
-        if (key === 'description' || key === 'examples' || key === '$comment' || key === 'title') continue;
-        compact[key] = compactToolSchema(child);
+        // affect argument validation. A schema can also legally define an
+        // argument *named* "description" or "title", so keys inside schema maps
+        // must not be mistaken for annotations.
+        if (!preserveMapKeys && TOOL_SCHEMA_ANNOTATION_KEYS.has(key)) continue;
+        const childIsSchemaMap = !preserveMapKeys && TOOL_SCHEMA_MAP_KEYS.has(key);
+        compact[key] = compactToolSchema(child, childIsSchemaMap);
     }
     return compact;
 }
@@ -1459,6 +1485,19 @@ function buildBoundedPrompt(systemPrompt, historyPrefix, conversationPrompt, max
     };
 }
 
+function buildRetryPrompt(systemPrompt, historyPrefix, conversationPrompt, currentPrompt, maxChars) {
+    const retryBuild = buildBoundedPrompt(systemPrompt, historyPrefix, conversationPrompt, maxChars);
+    const current = String(currentPrompt || '');
+    const prompt = retryBuild.prompt.length < current.length ? retryBuild.prompt : current;
+    return {
+        prompt,
+        compacted: prompt.length < current.length,
+        historyDropped: prompt === retryBuild.prompt && retryBuild.historyDropped,
+        originalChars: retryBuild.originalChars,
+        promptChars: prompt.length,
+    };
+}
+
 function appendPromptInstruction(promptText, instruction, maxChars = MAX_UPSTREAM_PROMPT_CHARS) {
     const suffix = `\n\n${String(instruction || '').trim()}`;
     const baseBudget = Math.max(0, maxChars - suffix.length);
@@ -1470,6 +1509,27 @@ function isContextTooLongError(error) {
         ? error
         : `${error?.content || ''} ${error?.message || ''} ${error?.finish_reason || ''} ${error?.type || ''}`;
     return /(?:content|prompt|context).{0,40}(?:too\s+long|too\s+large|length|limit|maximum)|maximum.{0,30}(?:context|token)|too\s+many\s+tokens|содержани[ея]\s+слишком\s+длин|контекст.{0,30}(?:длин|лимит)|内容.{0,12}(?:过长|太长)|上下文.{0,12}(?:过长|超出)/i.test(message);
+}
+
+function normalizeRetryResponse(result) {
+    return {
+        content: result?.content ? sanitizeContent(result.content) : '',
+        reasoningContent: result?.reasoningContent ? sanitizeContent(result.reasoningContent) : '',
+        finishReason: result?.finishReason ?? null,
+        modelError: result?.modelError || null,
+    };
+}
+
+function classifyRecoveryFailure(modelError, timedOut = false) {
+    if (isContextTooLongError(modelError)) return { status: 400, type: 'context_length_exceeded' };
+    if (timedOut) return { status: 504, type: 'request_timeout' };
+    return { status: 502, type: modelError?.type || 'empty_response' };
+}
+
+function isTimeoutError(error) {
+    const name = String(error?.name || '');
+    const message = String(error?.message || '');
+    return name === 'TimeoutError' || name === 'AbortError' || /(?:timed?\s*out|timeout)/i.test(message);
 }
 
 function formatMessages(messages, tools) {
@@ -1499,10 +1559,10 @@ function formatMessages(messages, tools) {
         } else if (msg.role === 'tool' && msg.content) {
             // Tool execution result — send back to DeepSeek as context
             const toolContent = normalizeMessageContent(msg.content);
-            const truncated = toolContent.length > 8000
-                ? truncatePromptMiddle(toolContent, 8000, 0.35)
-                : toolContent;
-            conversation += `[Tool Result]\n${truncated}\n\n`;
+            // Do not impose a second, per-result 8k limit: one large tool result
+            // may be the essential input. buildBoundedPrompt applies the single
+            // global request cap while preserving the latest conversation tail.
+            conversation += `[Tool Result]\n${toolContent}\n\n`;
         }
     }
     // The last user message + full conversation context
@@ -1519,8 +1579,7 @@ const server = http.createServer(async (req, res) => {
         return;
     }
     if (requestOrigin) res.setHeader('Access-Control-Allow-Origin', normalizeOrigin(requestOrigin));
-    res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    setCorsResponseHeaders(res);
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
 
     const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
@@ -1651,6 +1710,8 @@ const server = http.createServer(async (req, res) => {
         res.on('close', () => { clientGone = true; });
         const requestStartedAt = Date.now();
         const deadlineHit = () => Date.now() - requestStartedAt > REQUEST_DEADLINE_MS;
+        let activeSession = null;
+        let activeAgentId = null;
         try {
             const rawParams = JSON.parse(body || '{}');
             const params = normalizeApiParams(rawParams, apiMode);
@@ -1676,6 +1737,7 @@ const server = http.createServer(async (req, res) => {
                 ? String(requestedSession)
                 : ((remoteAddr === '127.0.0.1' || remoteAddr === '::1' || remoteAddr === '::ffff:127.0.0.1') ? 'dev-agent' : remoteAddr);
             const agentTag = `[${agentId}]`;
+            activeAgentId = agentId;
 
             // "/new" command: if the latest user message is exactly "/new" (whitespace-insensitive),
             // reset this agent's DeepSeek session/history instead of forwarding anything to DeepSeek.
@@ -1717,6 +1779,14 @@ const server = http.createServer(async (req, res) => {
             const clientPromptText = messages.map(m => normalizeMessageContent(m.content)).join('\n');
 
             const session = getOrCreateAgentSession(agentId);
+            activeSession = session;
+
+            // Roll over TTL/depth-limited sessions before deciding whether to
+            // inject local recovery history into the newly built prompt.
+            const promptRollover = prepareSessionForPrompt(session);
+            if (promptRollover) {
+                console.log(`${agentTag} Session ${promptRollover.failedSessionId} reset before prompt build (${promptRollover.reason}); recovery history preserved.`);
+            }
 
             // Build history prefix if starting fresh
             let historyPrefix = '';
@@ -1730,8 +1800,9 @@ const server = http.createServer(async (req, res) => {
 
             const promptBuild = buildBoundedPrompt(systemPrompt, historyPrefix, prompt);
             let fullPrompt = promptBuild.prompt;
+            let promptCompacted = promptBuild.compacted;
             if (promptBuild.compacted) {
-                res.setHeader('X-FreeDeepseek-Context-Compacted', 'true');
+                markContextCompacted(res);
                 console.log(`${agentTag} Compacted upstream prompt ${promptBuild.originalChars} -> ${promptBuild.promptChars} chars${promptBuild.historyDropped ? ' (recovery history dropped)' : ''}`);
             }
 
@@ -1855,53 +1926,55 @@ const server = http.createServer(async (req, res) => {
                     ? Math.max(0.35, 0.8 - retryAttempt * 0.2)
                     : Math.max(0.5, 1 - retryAttempt * 0.2);
                 const retryBudget = Math.max(MIN_UPSTREAM_PROMPT_CHARS, Math.floor(MAX_UPSTREAM_PROMPT_CHARS * retryRatio));
-                const retryBuild = buildBoundedPrompt(systemPrompt, '', prompt, retryBudget);
-                const retryPrompt = retryBuild.prompt.length < fullPrompt.length ? retryBuild.prompt : fullPrompt;
+                const retryBuild = buildRetryPrompt(systemPrompt, historyPrefix, prompt, fullPrompt, retryBudget);
+                const retryPrompt = retryBuild.prompt;
+                if (retryBuild.compacted) {
+                    promptCompacted = true;
+                    markContextCompacted(res);
+                }
                 const reason = contextTooLong ? 'context-too-long response' : 'empty response';
                 console.log(`${agentTag} ${reason} (msg#${session.messageCount}, retry ${retryAttempt}/${MAX_EMPTY_RETRIES}, prompt=${retryPrompt.length} chars). Resetting session...`);
-                session.id = null;
-                session.parentMessageId = null;
-                session.createdAt = null;
-                session.messageCount = 0;
+                resetRemoteSession(session);
                 // Brief delay before retry to let DeepSeek breathe
                 await new Promise(r => setTimeout(r, Math.min(500 * retryAttempt, 1500)));
                 const { resp: retryResp } = await askDeepSeekStream(retryPrompt, agentId, requestedModel);
                 const retryResult = await readDeepSeekResponse(retryResp.body);
-                const retryContent = retryResult && retryResult.content ? sanitizeContent(retryResult.content) : '';
-                const retryReasoning = retryResult && retryResult.reasoningContent ? sanitizeContent(retryResult.reasoningContent) : '';
+                const retryState = normalizeRetryResponse(retryResult);
                 fullPrompt = retryPrompt;
-                modelError = retryResult?.modelError || null;
-                finishReason = retryResult?.finishReason || finishReason;
-                if (retryContent && retryContent.trim().length > 0) {
+                modelError = retryState.modelError;
+                // A previous empty response may have carried finish_reason=length.
+                // Never leak it into a successful retry that supplied no reason.
+                finishReason = retryState.finishReason;
+                if (retryState.content && retryState.content.trim().length > 0) {
                     console.log(`${agentTag} Retry ${retryAttempt} succeeded`);
-                    fullContent = retryContent;
-                    reasoningContent = retryReasoning;
+                    fullContent = retryState.content;
+                    reasoningContent = retryState.reasoningContent;
                 }
             }
 
             if (!fullContent || fullContent.trim().length === 0) {
-                const contextTooLong = isContextTooLongError(modelError);
                 const timedOut = deadlineHit();
-                const errorType = contextTooLong
-                    ? 'context_length_exceeded'
-                    : (timedOut ? 'request_timeout' : (modelError?.type || 'empty_response'));
+                const failureClass = classifyRecoveryFailure(modelError, timedOut);
+                const failure = resetRemoteSession(session);
+                const errorType = failureClass.type;
                 const errorMessage = modelError?.content
                     || (timedOut
                         ? 'DeepSeek request deadline reached while recovering an empty response'
                         : `DeepSeek returned empty content after ${retryAttempt} retr${retryAttempt === 1 ? 'y' : 'ies'}`);
                 console.log(`${agentTag} ${errorType} after ${retryAttempt} retr${retryAttempt === 1 ? 'y' : 'ies'}. Giving up.`);
-                res.writeHead(502, { 'Content-Type': 'application/json' });
+                res.writeHead(failureClass.status, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify({
                     error: {
                         message: errorMessage,
                         type: errorType,
                         agent: agentId,
-                        session_id: session.id,
-                        message_count: session.messageCount,
+                        failed_session_id: failure.failedSessionId,
+                        message_count: failure.failedMessageCount,
                         history_length: session.history.length,
+                        account: failure.accountId,
                         retry_attempts: retryAttempt,
                         upstream_prompt_chars: fullPrompt.length,
-                        prompt_compacted: promptBuild.compacted || fullPrompt.length < promptBuild.promptChars,
+                        prompt_compacted: promptCompacted,
                         model: requestedModel,
                         real_model: resolveModelConfig(requestedModel).real_model,
                     }
@@ -1953,10 +2026,7 @@ const server = http.createServer(async (req, res) => {
             // malformed. Never pass raw DSML through as a normal assistant turn.
             if (allowedToolNames.size > 0 && !toolCall && looksLikeToolCallMarkup(fullContent) && !clientGone && !deadlineHit()) {
                 console.log(`${agentTag} Tool-call markup detected but invalid/truncated (${fullContent.length} chars). Retrying with stricter prompt...`);
-                session.id = null;
-                session.parentMessageId = null;
-                session.createdAt = null;
-                session.messageCount = 0;
+                resetRemoteSession(session);
                 await new Promise(r => setTimeout(r, 1000));
                 const strictPrompt = appendPromptInstruction(
                     fullPrompt,
@@ -1980,10 +2050,17 @@ const server = http.createServer(async (req, res) => {
             }
 
             if (allowedToolNames.size > 0 && !toolCall && looksLikeToolCallMarkup(fullContent)) {
+                const failure = resetRemoteSession(session);
                 res.writeHead(502, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify({ error: {
                     message: 'DeepSeek returned malformed tool-call markup after one repair attempt',
                     type: 'malformed_tool_call',
+                    agent: agentId,
+                    failed_session_id: failure.failedSessionId,
+                    message_count: failure.failedMessageCount,
+                    history_length: session.history.length,
+                    account: failure.accountId,
+                    prompt_compacted: promptCompacted,
                     model: requestedModel,
                     real_model: resolveModelConfig(requestedModel).real_model,
                 } }));
@@ -2032,11 +2109,23 @@ const server = http.createServer(async (req, res) => {
             if (res.headersSent || clientGone) return;  // streamed/aborted: nothing to send
             // Pool exhaustion / no-auth carry an explicit status so integrators see
             // 429/503 (not a generic 500) and can honor Retry-After.
-            const status = e.status || 500;
+            const timedOut = isTimeoutError(e);
+            const status = e.status || (timedOut ? 504 : 500);
             const headers = { 'Content-Type': 'application/json' };
             if (status === 429 && e.retryAfter) headers['Retry-After'] = String(e.retryAfter);
             res.writeHead(status, headers);
-            res.end(JSON.stringify({ error: { message: e.message, type: e.type || 'server_error' } }));
+            const failure = timedOut && activeSession ? resetRemoteSession(activeSession) : null;
+            res.end(JSON.stringify({ error: {
+                message: e.message,
+                type: e.type || (timedOut ? 'request_timeout' : 'server_error'),
+                ...(failure ? {
+                    agent: activeAgentId,
+                    failed_session_id: failure.failedSessionId,
+                    message_count: failure.failedMessageCount,
+                    history_length: activeSession.history.length,
+                    account: failure.accountId,
+                } : {}),
+            } }));
         } finally {
             inFlight--;
         }
@@ -2154,13 +2243,23 @@ module.exports = {
         truncatePromptMiddle,
         hasExplicitConversationHistory,
         buildBoundedPrompt,
+        buildRetryPrompt,
         isContextTooLongError,
+        normalizeRetryResponse,
+        classifyRecoveryFailure,
+        isTimeoutError,
+        formatMessages,
         createSession,
+        resetRemoteSession,
+        prepareSessionForPrompt,
         sweepIdleSessions,
         sessions,
         isProxyAuthorized,
         isLoopbackHost,
         normalizeOrigin,
         isBrowserOriginAllowed,
+        setCorsResponseHeaders,
+        markContextCompacted,
+        CONTEXT_COMPACTED_HEADER,
     },
 };

--- a/server.js
+++ b/server.js
@@ -722,6 +722,8 @@ const MAX_TOOL_MARKUP_CHARS = 256 * 1024;
 const MAX_TOOL_ARGUMENT_CHARS = 128 * 1024;
 const MAX_TOOL_JSON_CANDIDATES = 32;
 const MAX_DSML_PARAMETERS = 128;
+const MAX_DSML_STRUCTURAL_TAGS = MAX_DSML_PARAMETERS * 2 + 16;
+const MAX_DSML_TAG_CHARS = 2048;
 
 function extractBalancedJsonAt(text, startIndex) {
     if (text[startIndex] !== '{') return null;
@@ -889,30 +891,119 @@ function getMarkupAttribute(attrs, attribute) {
     return match ? match[2] : null;
 }
 
+function readDsmlTagAt(text, start) {
+    if (text[start] !== '<') return null;
+    const prefix = text.substring(start + 1, Math.min(text.length, start + 40)).trimStart();
+    if (!/^\/?(?:tool_calls|invoke|parameter|direct)\b/i.test(prefix)) return null;
+    let quote = null;
+    let end = -1;
+    const scanEnd = Math.min(text.length, start + MAX_DSML_TAG_CHARS + 1);
+    for (let i = start + 1; i < scanEnd; i++) {
+        const ch = text[i];
+        if (quote) {
+            if (ch === quote) quote = null;
+            continue;
+        }
+        if (ch === '"' || ch === "'") {
+            quote = ch;
+            continue;
+        }
+        if (ch === '>') {
+            end = i;
+            break;
+        }
+    }
+    if (end === -1) return { invalid: true };
+
+    let token = text.substring(start + 1, end).trim();
+    let closing = false;
+    if (token.startsWith('/')) {
+        closing = true;
+        token = token.substring(1).trim();
+    }
+    let selfClosing = false;
+    if (!closing && token.endsWith('/')) {
+        selfClosing = true;
+        token = token.substring(0, token.length - 1).trim();
+    }
+    const match = token.match(/^(tool_calls|invoke|parameter|direct)\b([\s\S]*)$/i);
+    if (!match) return null;
+    return {
+        name: match[1].toLowerCase(),
+        attrs: closing ? '' : match[2],
+        closing,
+        selfClosing,
+        start,
+        end: end + 1,
+    };
+}
+
+function scanDsmlStructuralTags(text) {
+    const tags = [];
+    const value = String(text || '');
+    for (let i = 0; i < value.length;) {
+        if (value.substring(i, i + 9).toUpperCase() === '<![CDATA[') {
+            const cdataEnd = value.indexOf(']]>', i + 9);
+            if (cdataEnd === -1) return null;
+            i = cdataEnd + 3;
+            continue;
+        }
+        if (value[i] !== '<') {
+            i++;
+            continue;
+        }
+        const tag = readDsmlTagAt(value, i);
+        if (!tag) {
+            i++;
+            continue;
+        }
+        if (tag.invalid) return null;
+        tags.push(tag);
+        if (tags.length > MAX_DSML_STRUCTURAL_TAGS) return null;
+        i = tag.end;
+    }
+    return tags;
+}
+
+function parseDsmlParameter(attrs, rawBody, args, seenNames) {
+    const parameterName = getMarkupAttribute(attrs, 'name');
+    if (!parameterName || !/^[A-Za-z0-9_][A-Za-z0-9_.:-]{0,127}$/.test(parameterName) || seenNames.has(parameterName)) return false;
+    seenNames.add(parameterName);
+    const stringMode = getMarkupAttribute(attrs, 'string');
+    const rawValue = decodeDsmlParameterValue(rawBody);
+    if (rawValue.length > MAX_TOOL_ARGUMENT_CHARS) return false;
+    let value = rawValue;
+    if (stringMode && stringMode.toLowerCase() === 'false') {
+        try { value = JSON.parse(rawValue.trim()); } catch (e) { return false; }
+    }
+    args[parameterName] = value;
+    return true;
+}
+
 function parseDsmlInvoke(name, body) {
+    const structuralTags = scanDsmlStructuralTags(body);
+    if (!structuralTags) return null;
+    const parameterTags = structuralTags.filter(tag => tag.name === 'parameter');
+    if (structuralTags.some(tag => tag.name !== 'parameter')) return null;
+
     const args = {};
     let parameterCount = 0;
     const seenNames = new Set();
-    const parameterRe = /<parameter\b([^>]*)>([\s\S]*?)<\/parameter>/gi;
-    let parameterMatch;
-    while ((parameterMatch = parameterRe.exec(body)) !== null) {
+    let cursor = 0;
+    for (let i = 0; i < parameterTags.length; i += 2) {
+        const opening = parameterTags[i];
+        const closing = parameterTags[i + 1];
+        if (!opening || opening.closing || opening.selfClosing || !closing || !closing.closing) return null;
+        if (body.substring(cursor, opening.start).trim()) return null;
         parameterCount++;
         if (parameterCount > MAX_DSML_PARAMETERS) return null;
-        const attrs = parameterMatch[1] || '';
-        const parameterName = getMarkupAttribute(attrs, 'name');
-        if (!parameterName || !/^[A-Za-z0-9_][A-Za-z0-9_.:-]{0,127}$/.test(parameterName) || seenNames.has(parameterName)) return null;
-        seenNames.add(parameterName);
-        const stringMode = getMarkupAttribute(attrs, 'string');
-        const rawValue = decodeDsmlParameterValue(parameterMatch[2]);
-        if (rawValue.length > MAX_TOOL_ARGUMENT_CHARS) return null;
-        let value = rawValue;
-        if (stringMode && stringMode.toLowerCase() === 'false') {
-            try { value = JSON.parse(rawValue.trim()); } catch (e) { return null; }
-        }
-        args[parameterName] = value;
+        if (!parseDsmlParameter(opening.attrs, body.substring(opening.end, closing.start), args, seenNames)) return null;
+        cursor = closing.end;
     }
-    if (/<parameter\b/i.test(body) && parameterCount === 0) return null;
-    if (parameterCount > 0) return buildToolCall(name, args);
+    if (parameterCount > 0) {
+        if (body.substring(cursor).trim()) return null;
+        return buildToolCall(name, args);
+    }
 
     const decodedBody = decodeDsmlValue(body).trim();
     if (!decodedBody) return buildToolCall(name, {});
@@ -923,23 +1014,28 @@ function parseDsmlInvoke(name, body) {
 }
 
 function extractToolCallScope(normalized) {
-    const lower = normalized.toLowerCase();
-    const openTag = '<tool_calls>';
-    const closeTag = '</tool_calls>';
-    const openIndex = lower.indexOf(openTag);
-    const closeIndex = lower.indexOf(closeTag, Math.max(0, openIndex + openTag.length));
-    if (openIndex !== -1) {
-        if (closeIndex === -1) return null;
-        if (lower.indexOf(openTag, openIndex + openTag.length) !== -1) return null;
-        if (lower.indexOf(closeTag, closeIndex + closeTag.length) !== -1) return null;
-        return normalized.substring(openIndex + openTag.length, closeIndex);
+    const tags = scanDsmlStructuralTags(normalized);
+    if (!tags) return null;
+    const wrappers = tags.filter(tag => tag.name === 'tool_calls');
+    const openings = wrappers.filter(tag => !tag.closing);
+    const closings = wrappers.filter(tag => tag.closing);
+    if (openings.length > 0) {
+        if (openings.length !== 1 || openings[0].selfClosing || closings.length === 0) return null;
+        const opening = openings[0];
+        const closing = closings[closings.length - 1];
+        if (wrappers.some(tag => tag.closing && tag.start < opening.end) || closing.start < opening.end) return null;
+        if (tags.some(tag => tag.name !== 'tool_calls' && (tag.start < opening.end || tag.start >= closing.start))) return null;
+        return normalized.substring(opening.end, closing.start);
     }
     // Narrow repair: tolerate a missing opening wrapper only when a closing
     // wrapper exists. A bare invoke without this sentinel is never executable.
-    if (closeIndex !== -1) {
-        const beforeClose = normalized.substring(0, closeIndex);
-        const invokeIndex = beforeClose.toLowerCase().lastIndexOf('<invoke');
-        if (invokeIndex !== -1) return beforeClose.substring(invokeIndex);
+    if (closings.length > 0) {
+        const closing = closings[closings.length - 1];
+        const invokeOpenings = tags.filter(tag => tag.name === 'invoke' && !tag.closing && tag.start < closing.start);
+        if (invokeOpenings.length === 1 && !invokeOpenings[0].selfClosing) {
+            if (tags.some(tag => tag.name !== 'tool_calls' && (tag.start < invokeOpenings[0].start || tag.start >= closing.start))) return null;
+            return normalized.substring(invokeOpenings[0].start, closing.start);
+        }
     }
     return null;
 }
@@ -949,25 +1045,27 @@ function parseDsmlToolCall(text) {
     const normalized = normalizeToolMarkupTags(text);
     const scope = extractToolCallScope(normalized);
     if (scope === null) return null;
-    const calls = [];
-    const invokeRe = /<invoke\b([^>]*)>([\s\S]*?)<\/invoke>/gi;
-    let invokeMatch;
-    while ((invokeMatch = invokeRe.exec(scope)) !== null) {
-        const name = getMarkupAttribute(invokeMatch[1], 'name');
-        const parsed = parseDsmlInvoke(name, invokeMatch[2]);
-        if (!parsed) return null;
-        calls.push(parsed);
-        if (calls.length > 1) return null;
-    }
-    if (calls.length === 1) {
-        console.log(`[parseToolCall] SUCCESS dsml: ${calls[0].name} (args=${calls[0].arguments.length} chars)`);
-        return calls[0];
-    }
-    if (/<invoke\b/i.test(scope)) return null;
+    const tags = scanDsmlStructuralTags(scope);
+    if (!tags || tags.length === 0) return null;
+    const first = tags[0];
+    if (scope.substring(0, first.start).trim()) return null;
 
-    const directMatch = scope.match(/^\s*<direct\b([^>]*)>([\s\S]*?)\s*$/i);
-    if (directMatch) {
-        const parsed = parseDsmlInvoke(getMarkupAttribute(directMatch[1], 'name'), directMatch[2]);
+    if (first.name === 'invoke' && !first.closing && !first.selfClosing) {
+        const invokeTags = tags.filter(tag => tag.name === 'invoke');
+        if (invokeTags.length !== 2 || invokeTags[0] !== first || invokeTags[1].closing !== true) return null;
+        const closing = invokeTags[1];
+        if (scope.substring(closing.end).trim()) return null;
+        if (tags.some(tag => (tag.name === 'tool_calls' || tag.name === 'direct'))) return null;
+        const parsed = parseDsmlInvoke(getMarkupAttribute(first.attrs, 'name'), scope.substring(first.end, closing.start));
+        if (parsed) {
+            console.log(`[parseToolCall] SUCCESS dsml: ${parsed.name} (args=${parsed.arguments.length} chars)`);
+            return parsed;
+        }
+    }
+
+    if (first.name === 'direct' && !first.closing && !first.selfClosing) {
+        if (tags.some((tag, index) => index > 0 && (tag.name === 'direct' || tag.name === 'invoke' || tag.name === 'tool_calls'))) return null;
+        const parsed = parseDsmlInvoke(getMarkupAttribute(first.attrs, 'name'), scope.substring(first.end));
         if (parsed) {
             console.log(`[parseToolCall] SUCCESS dsml-direct: ${parsed.name} (args=${parsed.arguments.length} chars)`);
             return parsed;

--- a/server.js
+++ b/server.js
@@ -648,7 +648,13 @@ function formatToolDefinitions(tools) {
     return text;
 }
 
+const MAX_TOOL_MARKUP_CHARS = 256 * 1024;
+const MAX_TOOL_ARGUMENT_CHARS = 128 * 1024;
+const MAX_TOOL_JSON_CANDIDATES = 32;
+const MAX_DSML_PARAMETERS = 128;
+
 function extractBalancedJsonAt(text, startIndex) {
+    if (text[startIndex] !== '{') return null;
     let braceDepth = 0;
     let inString = false;
     let escape = false;
@@ -668,26 +674,84 @@ function extractBalancedJsonAt(text, startIndex) {
     return null;
 }
 
-function coerceToolCallObject(obj) {
-    if (!obj || typeof obj !== 'object') return null;
-    const candidate = obj.tool_call || obj.tool || obj.function_call || obj;
-    if (!candidate || typeof candidate !== 'object') return null;
-    const fn = candidate.function && typeof candidate.function === 'object' ? candidate.function : candidate;
-    const name = fn.name || candidate.name || obj.name;
-    let args = fn.arguments ?? candidate.arguments ?? candidate.input ?? obj.arguments ?? obj.input ?? {};
-    if (!name || typeof name !== 'string') return null;
-    if (typeof args === 'string') {
-        try { args = JSON.parse(args); } catch (e) { args = { raw: args }; }
+function extractBalancedJsonObjects(text, maxObjects = MAX_TOOL_JSON_CANDIDATES) {
+    const objects = [];
+    let start = -1;
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (start === -1) {
+            if (ch === '{') {
+                start = i;
+                depth = 1;
+                inString = false;
+                escape = false;
+            }
+            continue;
+        }
+        if (escape) { escape = false; continue; }
+        if (ch === '\\' && inString) { escape = true; continue; }
+        if (ch === '"') { inString = !inString; continue; }
+        if (inString) continue;
+        if (ch === '{') depth++;
+        if (ch === '}') {
+            depth--;
+            if (depth === 0) {
+                objects.push(text.substring(start, i + 1));
+                if (objects.length >= maxObjects) return objects;
+                start = -1;
+            }
+        }
     }
-    if (!args || typeof args !== 'object' || Array.isArray(args)) args = { value: args };
-    return { name, arguments: JSON.stringify(args) };
+    return objects;
 }
 
-function parseJsonToolCandidate(raw, label = 'json') {
+function buildToolCall(name, args = {}) {
+    const toolName = typeof name === 'string' ? name.trim() : '';
+    if (!/^[A-Za-z0-9_][A-Za-z0-9_.:-]{0,127}$/.test(toolName)) return null;
+    let parsedArgs = args;
+    if (typeof parsedArgs === 'string') {
+        if (parsedArgs.length > MAX_TOOL_ARGUMENT_CHARS) return null;
+        try { parsedArgs = JSON.parse(parsedArgs); } catch (e) { return null; }
+    }
+    if (parsedArgs === null || parsedArgs === undefined) parsedArgs = {};
+    if (typeof parsedArgs !== 'object' || Array.isArray(parsedArgs)) return null;
+    let serialized;
+    try { serialized = JSON.stringify(parsedArgs); } catch (e) { return null; }
+    if (serialized.length > MAX_TOOL_ARGUMENT_CHARS) return null;
+    return { name: toolName, arguments: serialized };
+}
+
+function coerceToolCallObject(obj, { allowBare = false } = {}) {
+    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+    let candidate = null;
+    if (Object.prototype.hasOwnProperty.call(obj, 'tool_call')) {
+        candidate = obj.tool_call;
+    } else if (Object.prototype.hasOwnProperty.call(obj, 'function_call')) {
+        candidate = obj.function_call;
+    } else if (Object.prototype.hasOwnProperty.call(obj, 'tool_calls')) {
+        if (!Array.isArray(obj.tool_calls) || obj.tool_calls.length !== 1) return null;
+        candidate = obj.tool_calls[0];
+    } else if (allowBare) {
+        candidate = obj;
+    }
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null;
+    const fn = candidate.function && typeof candidate.function === 'object'
+        ? candidate.function
+        : candidate;
+    return buildToolCall(
+        fn.name ?? candidate.name,
+        fn.arguments ?? candidate.arguments ?? candidate.input ?? {}
+    );
+}
+
+function parseJsonToolCandidate(raw, label = 'json', options = {}) {
     if (!raw) return null;
     try {
         const parsed = JSON.parse(raw);
-        const tc = coerceToolCallObject(parsed);
+        const tc = coerceToolCallObject(parsed, options);
         if (tc) {
             console.log(`[parseToolCall] SUCCESS ${label}: ${tc.name} (args=${tc.arguments.length} chars)`);
             return tc;
@@ -698,14 +762,41 @@ function parseJsonToolCandidate(raw, label = 'json') {
     return null;
 }
 
-function normalizeDsmlTags(text) {
-    return String(text || '').replace(
-        /<\s*(\/?)\s*[|｜]+\s*DSML\s*[|｜]+\s*([^>]*)>/giu,
-        (_match, closing, suffix) => {
-            const trimmed = String(suffix || '').trim();
-            return `<${closing ? '/' : ''}|DSML|${trimmed ? ` ${trimmed}` : ''}>`;
-        }
-    );
+function canonicalizeToolMarkupTag(rawTag) {
+    let token = String(rawTag || '').trim()
+        .replace(/｜/g, '|')
+        .replace(/[“”＂]/g, '"')
+        .replace(/[‘’＇]/g, "'");
+    let closing = false;
+    if (token.startsWith('/')) {
+        closing = true;
+        token = token.substring(1).trim();
+    }
+    token = token.replace(/^\|+\s*DSML\s*\|+\s*/i, '');
+    if (token.startsWith('/')) {
+        closing = true;
+        token = token.substring(1).trim();
+    }
+    token = token.replace(/^DSML(?=(?:tool[\s_-]*calls|function[\s_-]*calls|invoke|parameter)\b)/i, '');
+
+    if (!closing && /^name\s*=/i.test(token)) return `<direct ${token}>`;
+
+    const semantic = token.match(/^(?:(?:[A-Za-z_][\w.-]*):)?(tool[\s_-]*calls|function[\s_-]*calls|invoke|parameter)\b([\s\S]*)$/i);
+    if (!semantic) return null;
+    const localName = semantic[1].replace(/[\s_-]/g, '').toLowerCase();
+    const canonicalName = localName === 'toolcalls' || localName === 'functioncalls'
+        ? 'tool_calls'
+        : localName;
+    const attrs = closing ? '' : semantic[2];
+    return `<${closing ? '/' : ''}${canonicalName}${attrs}>`;
+}
+
+function normalizeToolMarkupTags(text) {
+    const withAsciiAngles = String(text || '').replace(/＜/g, '<').replace(/＞/g, '>');
+    return withAsciiAngles.replace(/<([^<>]{0,1024})>/g, (whole, rawTag) => {
+        const canonical = canonicalizeToolMarkupTag(rawTag);
+        return canonical || whole;
+    });
 }
 
 function decodeDsmlValue(value) {
@@ -717,89 +808,119 @@ function decodeDsmlValue(value) {
         .replace(/&amp;/gi, '&');
 }
 
+function decodeDsmlParameterValue(value) {
+    const raw = String(value || '');
+    const cdata = raw.trim().match(/^<!\[CDATA\[([\s\S]*?)\]\]>$/i);
+    return cdata ? cdata[1] : decodeDsmlValue(raw);
+}
+
+function getMarkupAttribute(attrs, attribute) {
+    const match = String(attrs || '').match(new RegExp(`\\b${attribute}\\s*=\\s*(["'])([^"']+)\\1`, 'i'));
+    return match ? match[2] : null;
+}
+
 function parseDsmlInvoke(name, body) {
-    if (!name || !/^[A-Za-z0-9_.:-]+$/.test(name)) return null;
     const args = {};
     let parameterCount = 0;
-    const parameterRe = /<\|DSML\|\s*parameter\b([^>]*)>([\s\S]*?)<\/\|DSML\|\s*parameter\s*>/gi;
+    const seenNames = new Set();
+    const parameterRe = /<parameter\b([^>]*)>([\s\S]*?)<\/parameter>/gi;
     let parameterMatch;
     while ((parameterMatch = parameterRe.exec(body)) !== null) {
-        const attrs = parameterMatch[1] || '';
-        const nameMatch = attrs.match(/\bname\s*=\s*(["'])([^"']+)\1/i);
-        if (!nameMatch) continue;
-        const stringMatch = attrs.match(/\bstring\s*=\s*(["'])(true|false)\1/i);
-        const rawValue = decodeDsmlValue(parameterMatch[2]);
-        let value = rawValue;
-        if (!stringMatch || stringMatch[2].toLowerCase() === 'false') {
-            try { value = JSON.parse(rawValue.trim()); } catch (e) { value = rawValue; }
-        }
-        args[nameMatch[2]] = value;
         parameterCount++;
-    }
-    if (parameterCount > 0) return { name, arguments: JSON.stringify(args) };
-
-    // Some DeepSeek Web responses use a shortened DSML invoke whose body is
-    // already a JSON object instead of parameter elements.
-    const decodedBody = decodeDsmlValue(body).trim();
-    const braceIndex = decodedBody.indexOf('{');
-    if (braceIndex !== -1) {
-        const rawJson = extractBalancedJsonAt(decodedBody, braceIndex);
-        if (rawJson) {
-            try {
-                const parsed = JSON.parse(rawJson);
-                if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-                    return { name, arguments: JSON.stringify(parsed) };
-                }
-            } catch (e) { }
+        if (parameterCount > MAX_DSML_PARAMETERS) return null;
+        const attrs = parameterMatch[1] || '';
+        const parameterName = getMarkupAttribute(attrs, 'name');
+        if (!parameterName || !/^[A-Za-z0-9_][A-Za-z0-9_.:-]{0,127}$/.test(parameterName) || seenNames.has(parameterName)) return null;
+        seenNames.add(parameterName);
+        const stringMode = getMarkupAttribute(attrs, 'string');
+        const rawValue = decodeDsmlParameterValue(parameterMatch[2]);
+        if (rawValue.length > MAX_TOOL_ARGUMENT_CHARS) return null;
+        let value = rawValue;
+        if (stringMode && stringMode.toLowerCase() === 'false') {
+            try { value = JSON.parse(rawValue.trim()); } catch (e) { return null; }
         }
+        args[parameterName] = value;
+    }
+    if (/<parameter\b/i.test(body) && parameterCount === 0) return null;
+    if (parameterCount > 0) return buildToolCall(name, args);
+
+    const decodedBody = decodeDsmlValue(body).trim();
+    if (!decodedBody) return buildToolCall(name, {});
+    const objects = extractBalancedJsonObjects(decodedBody, 2);
+    if (objects.length !== 1 || decodedBody !== objects[0]) return null;
+    try { return buildToolCall(name, JSON.parse(objects[0])); }
+    catch (e) { return null; }
+}
+
+function extractToolCallScope(normalized) {
+    const lower = normalized.toLowerCase();
+    const openTag = '<tool_calls>';
+    const closeTag = '</tool_calls>';
+    const openIndex = lower.indexOf(openTag);
+    const closeIndex = lower.indexOf(closeTag, Math.max(0, openIndex + openTag.length));
+    if (openIndex !== -1) {
+        if (closeIndex === -1) return null;
+        if (lower.indexOf(openTag, openIndex + openTag.length) !== -1) return null;
+        if (lower.indexOf(closeTag, closeIndex + closeTag.length) !== -1) return null;
+        return normalized.substring(openIndex + openTag.length, closeIndex);
+    }
+    // Narrow repair: tolerate a missing opening wrapper only when a closing
+    // wrapper exists. A bare invoke without this sentinel is never executable.
+    if (closeIndex !== -1) {
+        const beforeClose = normalized.substring(0, closeIndex);
+        const invokeIndex = beforeClose.toLowerCase().lastIndexOf('<invoke');
+        if (invokeIndex !== -1) return beforeClose.substring(invokeIndex);
     }
     return null;
 }
 
 function parseDsmlToolCall(text) {
-    const normalized = normalizeDsmlTags(text);
-    const toolBlockRe = /<\|DSML\|\s*(?:tool[\s_-]*calls|function[\s_-]*calls)\s*>([\s\S]*?)<\/\|DSML\|\s*(?:tool[\s_-]*calls|function[\s_-]*calls)\s*>/i;
-    const toolBlock = toolBlockRe.exec(normalized);
-    const scope = toolBlock ? toolBlock[1] : normalized;
-    const invokeRe = /<\|DSML\|\s*(?:invoke\s+)?name\s*=\s*(["'])([^"']+)\1[^>]*>([\s\S]*?)<\/\|DSML\|\s*(?:invoke)?\s*>/gi;
+    if (String(text || '').length > MAX_TOOL_MARKUP_CHARS) return null;
+    const normalized = normalizeToolMarkupTags(text);
+    const scope = extractToolCallScope(normalized);
+    if (scope === null) return null;
+    const calls = [];
+    const invokeRe = /<invoke\b([^>]*)>([\s\S]*?)<\/invoke>/gi;
     let invokeMatch;
     while ((invokeMatch = invokeRe.exec(scope)) !== null) {
-        const parsed = parseDsmlInvoke(invokeMatch[2], invokeMatch[3]);
-        if (parsed) {
-            console.log(`[parseToolCall] SUCCESS dsml: ${parsed.name} (args=${parsed.arguments.length} chars)`);
-            return parsed;
-        }
+        const name = getMarkupAttribute(invokeMatch[1], 'name');
+        const parsed = parseDsmlInvoke(name, invokeMatch[2]);
+        if (!parsed) return null;
+        calls.push(parsed);
+        if (calls.length > 1) return null;
     }
+    if (calls.length === 1) {
+        console.log(`[parseToolCall] SUCCESS dsml: ${calls[0].name} (args=${calls[0].arguments.length} chars)`);
+        return calls[0];
+    }
+    if (/<invoke\b/i.test(scope)) return null;
 
-    // Seen in DeepSeek Web: <｜｜DSML｜｜ Tool Calls> followed by a direct
-    // <｜｜DSML｜｜ name="tool"> JSON body, with no separate invoke close tag.
-    // Only accept this tolerant form inside a complete Tool Calls wrapper.
-    if (toolBlock) {
-        const directMatch = scope.match(/<\|DSML\|\s*name\s*=\s*(["'])([^"']+)\1[^>]*>([\s\S]*)$/i);
-        if (directMatch) {
-            const parsed = parseDsmlInvoke(directMatch[2], directMatch[3]);
-            if (parsed) {
-                console.log(`[parseToolCall] SUCCESS dsml-direct: ${parsed.name} (args=${parsed.arguments.length} chars)`);
-                return parsed;
-            }
+    const directMatch = scope.match(/^\s*<direct\b([^>]*)>([\s\S]*?)\s*$/i);
+    if (directMatch) {
+        const parsed = parseDsmlInvoke(getMarkupAttribute(directMatch[1], 'name'), directMatch[2]);
+        if (parsed) {
+            console.log(`[parseToolCall] SUCCESS dsml-direct: ${parsed.name} (args=${parsed.arguments.length} chars)`);
+            return parsed;
         }
     }
     return null;
 }
 
 function looksLikeToolCallMarkup(text) {
-    return /TOOL_CALL:\s*[\w-]+|<tool_call\b|[|｜]+\s*DSML\s*[|｜]+/i.test(String(text || ''));
+    return /TOOL_CALL:\s*[\w-]+|<\s*tool_call\b|[|｜]+\s*DSML\s*[|｜]+|[<＜]\s*\/?\s*(?:DSML)?(?:[\w.-]+:)?(?:tool[\s_-]*calls|function[\s_-]*calls|invoke)\b|["'](?:tool_call|tool_calls|function_call)["']\s*:/i.test(String(text || ''));
 }
 
 function parseToolCall(text) {
     if (!text || typeof text !== 'string') return null;
+    if (text.length > MAX_TOOL_MARKUP_CHARS) {
+        console.log(`[parseToolCall] Refusing oversized tool markup candidate (${text.length} chars)`);
+        return null;
+    }
 
-    if (/[|｜]+\s*DSML\s*[|｜]+/i.test(text)) {
+    if (/[|｜]+\s*DSML\s*[|｜]+|[<＜]\s*\/?\s*(?:DSML)?(?:[\w.-]+:)?(?:tool[\s_-]*calls|function[\s_-]*calls|invoke)\b/i.test(text)) {
         const dsml = parseDsmlToolCall(text);
         if (dsml) return dsml;
-        console.log('[parseToolCall] DSML markup found but invoke was incomplete or malformed');
-        // Do not scan JSON inside malformed DSML as a standalone tool call: a
-        // normal argument named "name" could otherwise execute the wrong tool.
+        console.log('[parseToolCall] Tool markup found but wrapper/invoke was incomplete or malformed');
         return null;
     }
 
@@ -807,7 +928,7 @@ function parseToolCall(text) {
     const xmlMatch = text.match(/<tool_call[^>]*>([\s\S]*?)<\/tool_call>/i);
     if (xmlMatch) {
         const inner = xmlMatch[1].trim();
-        const tc = parseJsonToolCandidate(inner, 'xml');
+        const tc = parseJsonToolCandidate(inner, 'xml', { allowBare: true });
         if (tc) return tc;
     }
 
@@ -830,8 +951,11 @@ function parseToolCall(text) {
             if (rawJson) {
                 try {
                     const args = JSON.parse(rawJson);
-                    console.log(`[parseToolCall] SUCCESS legacy: ${name} (args=${rawJson.length} chars)`);
-                    return { name, arguments: JSON.stringify(args) };
+                    const tc = buildToolCall(name, args);
+                    if (tc) {
+                        console.log(`[parseToolCall] SUCCESS legacy: ${name} (args=${rawJson.length} chars)`);
+                        return tc;
+                    }
                 } catch (e) {
                     console.log(`[parseToolCall] legacy JSON.parse failed: ${e.message.substring(0,100)}`);
                 }
@@ -843,12 +967,9 @@ function parseToolCall(text) {
         }
     }
 
-    // First balanced JSON object in the whole response. Supports:
-    // {"tool_call":{"name":"...","arguments":{...}}}, {"name":"...","arguments":{...}}, etc.
-    for (let i = 0; i < text.length; i++) {
-        if (text[i] !== '{') continue;
-        const rawJson = extractBalancedJsonAt(text, i);
-        if (!rawJson) continue;
+    // Scan each top-level balanced object once (linear time). Only explicit
+    // tool-call envelopes are executable; bare {name, arguments} examples are not.
+    for (const rawJson of extractBalancedJsonObjects(text)) {
         const tc = parseJsonToolCandidate(rawJson, 'inline');
         if (tc) return tc;
     }

--- a/server.js
+++ b/server.js
@@ -93,7 +93,15 @@ let inFlight = 0;  // concurrent in-flight completions (backpressure cap)
 // loops), max concurrent completions, and the empty-response retry cap.
 const REQUEST_DEADLINE_MS = Number(process.env.DEEPSEEK_REQUEST_DEADLINE_MS || 120000);
 const MAX_CONCURRENT = Number(process.env.DEEPSEEK_MAX_CONCURRENT || 24);
-const MAX_EMPTY_RETRIES = Number(process.env.DEEPSEEK_MAX_RETRIES || 4);
+const configuredEmptyRetries = Number(process.env.DEEPSEEK_MAX_RETRIES);
+const MAX_EMPTY_RETRIES = Number.isFinite(configuredEmptyRetries)
+    ? Math.max(0, Math.min(10, Math.floor(configuredEmptyRetries)))
+    : 2;
+const MIN_UPSTREAM_PROMPT_CHARS = 16000;
+const configuredPromptChars = Number(process.env.DEEPSEEK_MAX_PROMPT_CHARS);
+const MAX_UPSTREAM_PROMPT_CHARS = Number.isFinite(configuredPromptChars)
+    ? Math.max(MIN_UPSTREAM_PROMPT_CHARS, Math.floor(configuredPromptChars))
+    : 80000;
 function buildBaseHeaders(config = DS_CONFIG) {
     return {
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
@@ -558,8 +566,26 @@ async function askDeepSeekStream(prompt, agentId, model = 'deepseek-default') {
 
 // === Tool Calling Support ===
 
+function compactToolSchema(value) {
+    if (Array.isArray(value)) return value.map(compactToolSchema);
+    if (!value || typeof value !== 'object') return value;
+    const compact = {};
+    for (const [key, child] of Object.entries(value)) {
+        // Descriptions/examples dominate large agent tool payloads but do not
+        // affect argument validation. Keep the structural schema intact.
+        if (key === 'description' || key === 'examples' || key === '$comment' || key === 'title') continue;
+        compact[key] = compactToolSchema(child);
+    }
+    return compact;
+}
+
 function formatToolDefinitions(tools) {
     if (!tools || tools.length === 0) return '';
+    const rawSchemaChars = tools.reduce((total, tool) => {
+        try { return total + JSON.stringify(tool?.function?.parameters || {}).length; }
+        catch (e) { return total; }
+    }, 0);
+    const compactSchemas = rawSchemaChars > Math.floor(MAX_UPSTREAM_PROMPT_CHARS * 0.4);
     let text = '\n\n--- TOOL REQUEST SYSTEM ---\n';
     text += 'You are an AI that ONLY REASONS and REQUESTS tool executions. You do NOT run any commands yourself.\n';
     text += 'When you need data from the local server, REQUEST exactly one tool call. Prefer strict JSON:\n';
@@ -578,9 +604,10 @@ function formatToolDefinitions(tools) {
         if (tool.type === 'function' && tool.function) {
             const fn = tool.function;
             text += `\n## ${fn.name}\n`;
-            text += `${fn.description || ''}\n`;
+            const description = String(fn.description || '').replace(/\s+/g, ' ').trim();
+            text += `${description.length > 500 ? description.substring(0, 497) + '...' : description}\n`;
             if (fn.parameters) {
-                text += `Parameters: ${JSON.stringify(fn.parameters)}\n`;
+                text += `Parameters: ${JSON.stringify(compactSchemas ? compactToolSchema(fn.parameters) : fn.parameters)}\n`;
             }
         }
     }
@@ -639,8 +666,110 @@ function parseJsonToolCandidate(raw, label = 'json') {
     return null;
 }
 
+function normalizeDsmlTags(text) {
+    return String(text || '').replace(
+        /<\s*(\/?)\s*[|｜]+\s*DSML\s*[|｜]+\s*([^>]*)>/giu,
+        (_match, closing, suffix) => {
+            const trimmed = String(suffix || '').trim();
+            return `<${closing ? '/' : ''}|DSML|${trimmed ? ` ${trimmed}` : ''}>`;
+        }
+    );
+}
+
+function decodeDsmlValue(value) {
+    return String(value || '')
+        .replace(/&quot;/gi, '"')
+        .replace(/&apos;/gi, "'")
+        .replace(/&lt;/gi, '<')
+        .replace(/&gt;/gi, '>')
+        .replace(/&amp;/gi, '&');
+}
+
+function parseDsmlInvoke(name, body) {
+    if (!name || !/^[A-Za-z0-9_.:-]+$/.test(name)) return null;
+    const args = {};
+    let parameterCount = 0;
+    const parameterRe = /<\|DSML\|\s*parameter\b([^>]*)>([\s\S]*?)<\/\|DSML\|\s*parameter\s*>/gi;
+    let parameterMatch;
+    while ((parameterMatch = parameterRe.exec(body)) !== null) {
+        const attrs = parameterMatch[1] || '';
+        const nameMatch = attrs.match(/\bname\s*=\s*(["'])([^"']+)\1/i);
+        if (!nameMatch) continue;
+        const stringMatch = attrs.match(/\bstring\s*=\s*(["'])(true|false)\1/i);
+        const rawValue = decodeDsmlValue(parameterMatch[2]);
+        let value = rawValue;
+        if (!stringMatch || stringMatch[2].toLowerCase() === 'false') {
+            try { value = JSON.parse(rawValue.trim()); } catch (e) { value = rawValue; }
+        }
+        args[nameMatch[2]] = value;
+        parameterCount++;
+    }
+    if (parameterCount > 0) return { name, arguments: JSON.stringify(args) };
+
+    // Some DeepSeek Web responses use a shortened DSML invoke whose body is
+    // already a JSON object instead of parameter elements.
+    const decodedBody = decodeDsmlValue(body).trim();
+    const braceIndex = decodedBody.indexOf('{');
+    if (braceIndex !== -1) {
+        const rawJson = extractBalancedJsonAt(decodedBody, braceIndex);
+        if (rawJson) {
+            try {
+                const parsed = JSON.parse(rawJson);
+                if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                    return { name, arguments: JSON.stringify(parsed) };
+                }
+            } catch (e) { }
+        }
+    }
+    return null;
+}
+
+function parseDsmlToolCall(text) {
+    const normalized = normalizeDsmlTags(text);
+    const toolBlockRe = /<\|DSML\|\s*(?:tool[\s_-]*calls|function[\s_-]*calls)\s*>([\s\S]*?)<\/\|DSML\|\s*(?:tool[\s_-]*calls|function[\s_-]*calls)\s*>/i;
+    const toolBlock = toolBlockRe.exec(normalized);
+    const scope = toolBlock ? toolBlock[1] : normalized;
+    const invokeRe = /<\|DSML\|\s*(?:invoke\s+)?name\s*=\s*(["'])([^"']+)\1[^>]*>([\s\S]*?)<\/\|DSML\|\s*(?:invoke)?\s*>/gi;
+    let invokeMatch;
+    while ((invokeMatch = invokeRe.exec(scope)) !== null) {
+        const parsed = parseDsmlInvoke(invokeMatch[2], invokeMatch[3]);
+        if (parsed) {
+            console.log(`[parseToolCall] SUCCESS dsml: ${parsed.name} (args=${parsed.arguments.length} chars)`);
+            return parsed;
+        }
+    }
+
+    // Seen in DeepSeek Web: <｜｜DSML｜｜ Tool Calls> followed by a direct
+    // <｜｜DSML｜｜ name="tool"> JSON body, with no separate invoke close tag.
+    // Only accept this tolerant form inside a complete Tool Calls wrapper.
+    if (toolBlock) {
+        const directMatch = scope.match(/<\|DSML\|\s*name\s*=\s*(["'])([^"']+)\1[^>]*>([\s\S]*)$/i);
+        if (directMatch) {
+            const parsed = parseDsmlInvoke(directMatch[2], directMatch[3]);
+            if (parsed) {
+                console.log(`[parseToolCall] SUCCESS dsml-direct: ${parsed.name} (args=${parsed.arguments.length} chars)`);
+                return parsed;
+            }
+        }
+    }
+    return null;
+}
+
+function looksLikeToolCallMarkup(text) {
+    return /TOOL_CALL:\s*[\w-]+|<tool_call\b|[|｜]+\s*DSML\s*[|｜]+/i.test(String(text || ''));
+}
+
 function parseToolCall(text) {
     if (!text || typeof text !== 'string') return null;
+
+    if (/[|｜]+\s*DSML\s*[|｜]+/i.test(text)) {
+        const dsml = parseDsmlToolCall(text);
+        if (dsml) return dsml;
+        console.log('[parseToolCall] DSML markup found but invoke was incomplete or malformed');
+        // Do not scan JSON inside malformed DSML as a standalone tool call: a
+        // normal argument named "name" could otherwise execute the wrong tool.
+        return null;
+    }
 
     // XML-ish wrappers used by some agent prompts.
     const xmlMatch = text.match(/<tool_call[^>]*>([\s\S]*?)<\/tool_call>/i);
@@ -1115,11 +1244,86 @@ function extractScreenshotPaths(messages) {
     return paths;
 }
 
+const PROMPT_COMPACTION_MARKER = '\n\n[Earlier context compacted by FreeDeepseekAPI]\n\n';
+
+function truncatePromptMiddle(text, maxChars, headRatio = 0.35) {
+    const value = String(text || '');
+    if (value.length <= maxChars) return value;
+    if (maxChars <= 0) return '';
+    if (maxChars <= PROMPT_COMPACTION_MARKER.length) return value.substring(value.length - maxChars);
+    const payloadChars = maxChars - PROMPT_COMPACTION_MARKER.length;
+    const headChars = Math.max(0, Math.min(payloadChars, Math.floor(payloadChars * headRatio)));
+    const tailChars = payloadChars - headChars;
+    return value.substring(0, headChars) + PROMPT_COMPACTION_MARKER + value.substring(value.length - tailChars);
+}
+
+function hasExplicitConversationHistory(messages) {
+    const turns = (messages || []).filter(msg => msg && msg.role !== 'system');
+    return turns.length > 1 || turns.some(msg => msg.role === 'assistant' || msg.role === 'tool');
+}
+
+function buildBoundedPrompt(systemPrompt, historyPrefix, conversationPrompt, maxChars = MAX_UPSTREAM_PROMPT_CHARS) {
+    const system = String(systemPrompt || '').trim();
+    const history = String(historyPrefix || '');
+    const conversation = String(conversationPrompt || '').trim();
+    const original = system ? `${system}\n\n${history}${conversation}` : `${history}${conversation}`;
+    const safeMax = Math.max(1, Math.floor(Number(maxChars) || MAX_UPSTREAM_PROMPT_CHARS));
+    if (original.length <= safeMax) {
+        return { prompt: original, compacted: false, historyDropped: false, originalChars: original.length, promptChars: original.length };
+    }
+
+    // Server-side history is only a recovery hint. Drop it before truncating
+    // client-provided messages, which may already contain the same turns.
+    const historyDropped = history.length > 0;
+    const currentConversation = conversation;
+    const separatorLength = system && currentConversation ? 2 : 0;
+    let systemBudget = system ? Math.floor((safeMax - separatorLength) * 0.5) : 0;
+    let conversationBudget = Math.max(0, safeMax - separatorLength - systemBudget);
+
+    // Give unused capacity from a short side to the other side.
+    if (system.length < systemBudget) {
+        systemBudget = system.length;
+        conversationBudget = Math.max(0, safeMax - separatorLength - systemBudget);
+    } else if (currentConversation.length < conversationBudget) {
+        conversationBudget = currentConversation.length;
+        systemBudget = Math.max(0, safeMax - separatorLength - conversationBudget);
+    }
+
+    // Preserve the start of the task/system instructions and the most recent
+    // tool loop. The injected tool adapter lives at the end of systemPrompt.
+    const boundedSystem = truncatePromptMiddle(system, systemBudget, 0.35);
+    const boundedConversation = truncatePromptMiddle(currentConversation, conversationBudget, 0.25);
+    let bounded = boundedSystem && boundedConversation
+        ? `${boundedSystem}\n\n${boundedConversation}`
+        : (boundedSystem || boundedConversation);
+    if (bounded.length > safeMax) bounded = bounded.substring(0, safeMax);
+    return {
+        prompt: bounded,
+        compacted: true,
+        historyDropped,
+        originalChars: original.length,
+        promptChars: bounded.length,
+    };
+}
+
+function appendPromptInstruction(promptText, instruction, maxChars = MAX_UPSTREAM_PROMPT_CHARS) {
+    const suffix = `\n\n${String(instruction || '').trim()}`;
+    const baseBudget = Math.max(0, maxChars - suffix.length);
+    return truncatePromptMiddle(promptText, baseBudget, 0.35) + suffix;
+}
+
+function isContextTooLongError(error) {
+    const message = typeof error === 'string'
+        ? error
+        : `${error?.content || ''} ${error?.message || ''} ${error?.finish_reason || ''} ${error?.type || ''}`;
+    return /(?:content|prompt|context).{0,40}(?:too\s+long|too\s+large|length|limit|maximum)|maximum.{0,30}(?:context|token)|too\s+many\s+tokens|содержани[ея]\s+слишком\s+длин|контекст.{0,30}(?:длин|лимит)|内容.{0,12}(?:过长|太长)|上下文.{0,12}(?:过长|超出)/i.test(message);
+}
+
 function formatMessages(messages, tools) {
     let systemPrompt = '';
     for (const msg of messages) {
         if (msg.role === 'system' && msg.content) {
-            systemPrompt += msg.content + '\n';
+            systemPrompt += normalizeMessageContent(msg.content) + '\n';
         }
     }
     systemPrompt += formatToolDefinitions(tools);
@@ -1129,7 +1333,7 @@ function formatMessages(messages, tools) {
     for (const msg of messages) {
         if (msg.role === 'system') continue;  // already in systemPrompt
         if (msg.role === 'user' && msg.content) {
-            conversation += `User: ${msg.content}\n\n`;
+            conversation += `User: ${normalizeMessageContent(msg.content)}\n\n`;
         } else if (msg.role === 'assistant') {
             if (msg.tool_calls && msg.tool_calls.length > 0) {
                 // This was a tool call response from a previous turn
@@ -1137,13 +1341,14 @@ function formatMessages(messages, tools) {
                     conversation += `Assistant: TOOL_CALL: ${tc.function.name}\narguments: ${tc.function.arguments}\n\n`;
                 }
             } else if (msg.content) {
-                conversation += `Assistant: ${msg.content}\n\n`;
+                conversation += `Assistant: ${normalizeMessageContent(msg.content)}\n\n`;
             }
         } else if (msg.role === 'tool' && msg.content) {
             // Tool execution result — send back to DeepSeek as context
-            const truncated = msg.content.length > 8000
-                ? msg.content.substring(0, 8000) + '\n...[truncated]'
-                : msg.content;
+            const toolContent = normalizeMessageContent(msg.content);
+            const truncated = toolContent.length > 8000
+                ? truncatePromptMiddle(toolContent, 8000, 0.35)
+                : toolContent;
             conversation += `[Tool Result]\n${truncated}\n\n`;
         }
     }
@@ -1344,7 +1549,7 @@ const server = http.createServer(async (req, res) => {
 
             // Build history prefix if starting fresh
             let historyPrefix = '';
-            if (!session.id && session.history.length > 0) {
+            if (!session.id && session.history.length > 0 && !hasExplicitConversationHistory(messages)) {
                 historyPrefix = '[Previous conversation]\n';
                 for (const exchange of session.history) {
                     historyPrefix += `User: ${exchange.user}\nAssistant: ${exchange.assistant}\n\n`;
@@ -1352,9 +1557,12 @@ const server = http.createServer(async (req, res) => {
                 historyPrefix += '[Continue from here]\n\n';
             }
 
-            const fullPrompt = systemPrompt
-                ? `${systemPrompt}\n\n${historyPrefix}${prompt}`
-                : `${historyPrefix}${prompt}`;
+            const promptBuild = buildBoundedPrompt(systemPrompt, historyPrefix, prompt);
+            let fullPrompt = promptBuild.prompt;
+            if (promptBuild.compacted) {
+                res.setHeader('X-FreeDeepseek-Context-Compacted', 'true');
+                console.log(`${agentTag} Compacted upstream prompt ${promptBuild.originalChars} -> ${promptBuild.promptChars} chars${promptBuild.historyDropped ? ' (recovery history dropped)' : ''}`);
+            }
 
             const startTime = Date.now();
             const { resp: dsResp } = await askDeepSeekStream(fullPrompt, agentId, requestedModel);
@@ -1459,52 +1667,75 @@ const server = http.createServer(async (req, res) => {
             const elapsed = Date.now() - startTime;
             console.log(`${agentTag} Got ${fullContent.length} chars (+${reasoningContent.length} reasoning chars) in ${elapsed}ms (msg#${session.messageCount})`);
 
-            if ((!fullContent || fullContent.trim().length === 0) && modelError) {
-                res.writeHead(502, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ error: { message: modelError.content || 'DeepSeek returned an error without content', type: modelError.finish_reason || modelError.type || 'deepseek_model_error', model: requestedModel, real_model: resolveModelConfig(requestedModel).real_model } }));
-                return;
-            }
-
-            // Empty response — retry loop with fresh sessions
+            // Empty/context-overflow recovery. Each retry gets a smaller prompt
+            // and a fresh remote session; bounded attempts prevent retry storms.
             let retryAttempt = 0;
             while (!fullContent || fullContent.trim().length === 0) {
                 // Stop early if the client hung up or we've blown the request budget —
                 // no point burning more PoW solves + account quota for a dead socket.
                 if (clientGone) { console.log(`${agentTag} client disconnected; abandoning empty-retry loop`); return; }
                 if (deadlineHit()) { console.log(`${agentTag} request deadline hit; stopping empty-retry loop`); break; }
+                const contextTooLong = isContextTooLongError(modelError);
+                if (modelError && !contextTooLong) break;
+                if (retryAttempt >= MAX_EMPTY_RETRIES) break;
                 retryAttempt++;
-                if (retryAttempt > MAX_EMPTY_RETRIES) {
-                    console.log(`${agentTag} Empty after ${MAX_EMPTY_RETRIES} retries. Giving up.`);
-                    res.writeHead(502, { 'Content-Type': 'application/json' });
-                    res.end(JSON.stringify({
-                        error: {
-                            message: `DeepSeek returned empty content after ${MAX_EMPTY_RETRIES} retries`,
-                            type: 'empty_response',
-                            agent: agentId,
-                            session_id: session.id,
-                            message_count: session.messageCount,
-                            history_length: session.history.length,
-                            retry_attempts: retryAttempt - 1,
-                        }
-                    }));
-                    return;
-                }
-                console.log(`${agentTag} Empty response (msg#${session.messageCount}, retry ${retryAttempt}/${MAX_EMPTY_RETRIES}). Resetting session...`);
+
+                const retryRatio = contextTooLong
+                    ? Math.max(0.35, 0.8 - retryAttempt * 0.2)
+                    : Math.max(0.5, 1 - retryAttempt * 0.2);
+                const retryBudget = Math.max(MIN_UPSTREAM_PROMPT_CHARS, Math.floor(MAX_UPSTREAM_PROMPT_CHARS * retryRatio));
+                const retryBuild = buildBoundedPrompt(systemPrompt, '', prompt, retryBudget);
+                const retryPrompt = retryBuild.prompt.length < fullPrompt.length ? retryBuild.prompt : fullPrompt;
+                const reason = contextTooLong ? 'context-too-long response' : 'empty response';
+                console.log(`${agentTag} ${reason} (msg#${session.messageCount}, retry ${retryAttempt}/${MAX_EMPTY_RETRIES}, prompt=${retryPrompt.length} chars). Resetting session...`);
                 session.id = null;
                 session.parentMessageId = null;
                 session.createdAt = null;
                 session.messageCount = 0;
                 // Brief delay before retry to let DeepSeek breathe
-                await new Promise(r => setTimeout(r, Math.min(1000 * retryAttempt, 5000)));
-                const { resp: retryResp } = await askDeepSeekStream(fullPrompt, agentId, requestedModel);
+                await new Promise(r => setTimeout(r, Math.min(500 * retryAttempt, 1500)));
+                const { resp: retryResp } = await askDeepSeekStream(retryPrompt, agentId, requestedModel);
                 const retryResult = await readDeepSeekResponse(retryResp.body);
                 const retryContent = retryResult && retryResult.content ? sanitizeContent(retryResult.content) : '';
                 const retryReasoning = retryResult && retryResult.reasoningContent ? sanitizeContent(retryResult.reasoningContent) : '';
+                fullPrompt = retryPrompt;
+                modelError = retryResult?.modelError || null;
+                finishReason = retryResult?.finishReason || finishReason;
                 if (retryContent && retryContent.trim().length > 0) {
                     console.log(`${agentTag} Retry ${retryAttempt} succeeded`);
                     fullContent = retryContent;
                     reasoningContent = retryReasoning;
                 }
+            }
+
+            if (!fullContent || fullContent.trim().length === 0) {
+                const contextTooLong = isContextTooLongError(modelError);
+                const timedOut = deadlineHit();
+                const errorType = contextTooLong
+                    ? 'context_length_exceeded'
+                    : (timedOut ? 'request_timeout' : (modelError?.type || 'empty_response'));
+                const errorMessage = modelError?.content
+                    || (timedOut
+                        ? 'DeepSeek request deadline reached while recovering an empty response'
+                        : `DeepSeek returned empty content after ${retryAttempt} retr${retryAttempt === 1 ? 'y' : 'ies'}`);
+                console.log(`${agentTag} ${errorType} after ${retryAttempt} retr${retryAttempt === 1 ? 'y' : 'ies'}. Giving up.`);
+                res.writeHead(502, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({
+                    error: {
+                        message: errorMessage,
+                        type: errorType,
+                        agent: agentId,
+                        session_id: session.id,
+                        message_count: session.messageCount,
+                        history_length: session.history.length,
+                        retry_attempts: retryAttempt,
+                        upstream_prompt_chars: fullPrompt.length,
+                        prompt_compacted: promptBuild.compacted || fullPrompt.length < promptBuild.promptChars,
+                        model: requestedModel,
+                        real_model: resolveModelConfig(requestedModel).real_model,
+                    }
+                }));
+                return;
             }
 
             // Auto-continuation: if finish_reason is 'length' or content is very long (>25000 chars),
@@ -1538,32 +1769,54 @@ const server = http.createServer(async (req, res) => {
                 }
             }
 
-            let toolCall = parseToolCall(fullContent);
+            const allowedToolNames = new Set(tools
+                .filter(tool => tool?.type === 'function' && tool.function?.name)
+                .map(tool => tool.function.name));
+            let toolCall = allowedToolNames.size > 0 ? parseToolCall(fullContent) : null;
+            if (toolCall && !allowedToolNames.has(toolCall.name)) {
+                console.log(`${agentTag} Model requested unknown tool ${toolCall.name}; attempting format repair.`);
+                toolCall = null;
+            }
             
-            // Retry if TOOL_CALL was found but JSON was truncated/invalid
-            if (!toolCall && /TOOL_CALL:\s*\w/i.test(fullContent)) {
-                console.log(`${agentTag} TOOL_CALL detected but JSON invalid/truncated (${fullContent.length} chars). Retrying with stricter prompt...`);
+            // Retry once if legacy, XML, or DSML tool markup was truncated or
+            // malformed. Never pass raw DSML through as a normal assistant turn.
+            if (allowedToolNames.size > 0 && !toolCall && looksLikeToolCallMarkup(fullContent) && !clientGone && !deadlineHit()) {
+                console.log(`${agentTag} Tool-call markup detected but invalid/truncated (${fullContent.length} chars). Retrying with stricter prompt...`);
                 session.id = null;
                 session.parentMessageId = null;
                 session.createdAt = null;
                 session.messageCount = 0;
                 await new Promise(r => setTimeout(r, 1000));
-                const strictPrompt = fullPrompt + '\n\n[STRICT INSTRUCTION] Your previous response had a TOOL_CALL but the arguments were too long and got cut off. Keep the arguments SHORT — no large file contents. Just use a minimal example or reference the file by name. Output ONLY: TOOL_CALL: <function>\narguments: <short JSON>';
+                const strictPrompt = appendPromptInstruction(
+                    fullPrompt,
+                    '[STRICT INSTRUCTION] Your previous response contained incomplete tool-call markup. Keep arguments short and output ONLY strict JSON: {"tool_call":{"name":"<function>","arguments":{...}}}'
+                );
                 const { resp: retryResp2 } = await askDeepSeekStream(strictPrompt, agentId, requestedModel);
                 const retryResult2 = await readDeepSeekResponse(retryResp2.body);
                 const retryContent2 = retryResult2 && retryResult2.content ? sanitizeContent(retryResult2.content) : '';
                 if (retryContent2 && retryContent2.trim()) {
                     const retryTc = parseToolCall(retryContent2);
-                    if (retryTc) {
+                    if (retryTc && allowedToolNames.has(retryTc.name)) {
                         console.log(`${agentTag} Retry with strict prompt succeeded: ${retryTc.name}`);
                         fullContent = retryContent2;
                         reasoningContent = retryResult2.reasoningContent ? sanitizeContent(retryResult2.reasoningContent) : '';
                         toolCall = retryTc;
                     } else {
-                        console.log(`${agentTag} Retry still has broken JSON. Sending as text.`);
+                        console.log(`${agentTag} Retry still has broken tool markup. Returning a safe error instead of leaking it as text.`);
                         reasoningContent = retryResult2.reasoningContent ? sanitizeContent(retryResult2.reasoningContent) : reasoningContent;
                     }
                 }
+            }
+
+            if (allowedToolNames.size > 0 && !toolCall && looksLikeToolCallMarkup(fullContent)) {
+                res.writeHead(502, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: {
+                    message: 'DeepSeek returned malformed tool-call markup after one repair attempt',
+                    type: 'malformed_tool_call',
+                    model: requestedModel,
+                    real_model: resolveModelConfig(requestedModel).real_model,
+                } }));
+                return;
             }
             
             // Check if any tool results in the current conversation contained a screenshot path.
@@ -1722,6 +1975,15 @@ module.exports = {
         isDeepSeekModelErrorEvent,
         rebuildFragmentText,
         applyResponsePatchOperations,
+        compactToolSchema,
+        formatToolDefinitions,
+        parseToolCall,
+        parseDsmlToolCall,
+        looksLikeToolCallMarkup,
+        truncatePromptMiddle,
+        hasExplicitConversationHistory,
+        buildBoundedPrompt,
+        isContextTooLongError,
         createSession,
         sweepIdleSessions,
         sessions,

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -180,6 +180,18 @@ test('DeepSeek stream parser does not treat service content chunks as model erro
   assert.equal(serverInternals.isDeepSeekModelErrorEvent({ type: 'error', content: 'backend error' }), true);
 });
 
+test('consumed upstream HTTP errors retain status, type, and retry hints', () => {
+  const limited = serverInternals.createUpstreamHttpError(429, '  Rate limited\ntry later  ', '12');
+  assert.equal(limited.status, 429);
+  assert.equal(limited.type, 'rate_limit_error');
+  assert.equal(limited.retryAfter, '12');
+  assert.match(limited.message, /Rate limited try later/);
+
+  const unauthorized = serverInternals.createUpstreamHttpError(401, 'expired');
+  assert.equal(unauthorized.status, 401);
+  assert.equal(unauthorized.type, 'authentication_error');
+});
+
 test('sweepIdleSessions evicts only idle entries', () => {
   serverInternals.sessions.set('stale-x', { lastActivityAt: 1 });
   serverInternals.sessions.set('fresh-x', { lastActivityAt: Date.now() });
@@ -372,6 +384,35 @@ test('tool schema compaction drops prose annotations but preserves validation sh
   });
 });
 
+test('tool schema compaction preserves literal const, enum, and default values', () => {
+  const literals = {
+    type: 'object',
+    description: 'drop this annotation',
+    const: { description: 'literal field', title: 'literal title', nested: { examples: ['literal'] } },
+    enum: [
+      { description: 'first', value: 1 },
+      { title: 'second', value: 2 },
+    ],
+    default: { description: 'default literal', title: 'default title' },
+    properties: {
+      choice: {
+        description: 'drop nested annotation',
+        const: { description: 'required argument value', title: 'keep me' },
+      },
+    },
+  };
+
+  assert.deepEqual(serverInternals.compactToolSchema(literals), {
+    type: 'object',
+    const: literals.const,
+    enum: literals.enum,
+    default: literals.default,
+    properties: {
+      choice: { const: literals.properties.choice.const },
+    },
+  });
+});
+
 test('buildBoundedPrompt preserves task edges and drops duplicate recovery history', () => {
   const system = `SYSTEM_START\n${'s'.repeat(50000)}\nTOOL_ADAPTER_END`;
   const history = `[Previous conversation]\n${'h'.repeat(10000)}\n`;
@@ -424,6 +465,28 @@ test('empty-response retry keeps recovery history unless a smaller global cap re
   assert.ok(smallerRetry.prompt.length <= 4000);
   assert.match(smallerRetry.prompt, /TASK_START/);
   assert.match(smallerRetry.prompt, /LATEST_RESULT/);
+});
+
+test('fresh-session retry restores local history that a healthy remote session initially omitted', () => {
+  const system = 'SYSTEM';
+  const history = serverInternals.buildRecoveryHistoryPrefix([
+    { user: 'original task', assistant: 'original answer' },
+  ]);
+  const conversation = 'User: follow up';
+  const establishedSessionPrompt = serverInternals.buildBoundedPrompt(system, '', conversation, 5000).prompt;
+  const freshSessionRetry = serverInternals.buildRetryPrompt(
+    system,
+    history,
+    conversation,
+    establishedSessionPrompt,
+    5000,
+  );
+
+  assert.ok(freshSessionRetry.prompt.length > establishedSessionPrompt.length);
+  assert.match(freshSessionRetry.prompt, /Previous conversation/);
+  assert.match(freshSessionRetry.prompt, /original task/);
+  assert.match(freshSessionRetry.prompt, /original answer/);
+  assert.match(freshSessionRetry.prompt, /follow up/);
 });
 
 test('remote reset preserves local history and sticky account while returning failure diagnostics', () => {
@@ -515,4 +578,29 @@ test('context-compaction header is marked and exposed to browser clients', () =>
 
   assert.equal(headers.get('Access-Control-Expose-Headers'), serverInternals.CONTEXT_COMPACTED_HEADER);
   assert.equal(headers.get(serverInternals.CONTEXT_COMPACTED_HEADER), 'true');
+});
+
+test('stream helpers preserve the request-level exact CORS origin', () => {
+  const response = {
+    id: 'ds-test',
+    created: 1,
+    model: 'deepseek-chat',
+    choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+
+  for (const send of [
+    serverInternals.sendAnthropicStream,
+    serverInternals.sendResponsesStream,
+    serverInternals.sendOpenAIStream,
+  ]) {
+    let writeHeadHeaders = null;
+    const res = {
+      writeHead: (_status, headers) => { writeHeadHeaders = headers; },
+      write: () => {},
+      end: () => {},
+    };
+    send(res, response);
+    assert.equal(Object.hasOwn(writeHeadHeaders, 'Access-Control-Allow-Origin'), false);
+  }
 });

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -111,6 +111,42 @@ test('chrome auth prints actionable OS instructions when Chrome is missing', () 
   assert.match(out, /CHROME_PATH/i);
 });
 
+test('chrome extension manifest only declares icon files that exist', () => {
+  const manifestPath = path.join(ROOT, 'chrome-extension', 'manifest.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const iconPaths = [];
+
+  function collectIconPaths(value, key = '') {
+    if (typeof value === 'string') {
+      if (key === 'icons' || key === 'default_icon') iconPaths.push(value);
+      return;
+    }
+
+    if (!value || typeof value !== 'object') return;
+
+    if ((key === 'icons' || key === 'default_icon') && !Array.isArray(value)) {
+      for (const iconPath of Object.values(value)) {
+        if (typeof iconPath === 'string') iconPaths.push(iconPath);
+      }
+      return;
+    }
+
+    for (const [childKey, childValue] of Object.entries(value)) {
+      collectIconPaths(childValue, childKey);
+    }
+  }
+
+  collectIconPaths(manifest);
+
+  for (const iconPath of iconPaths) {
+    assert.equal(
+      fs.existsSync(path.join(path.dirname(manifestPath), iconPath)),
+      true,
+      `Missing extension icon declared in manifest: ${iconPath}`,
+    );
+  }
+});
+
 test('DeepSeek stream parser treats SEARCH fragments as assistant output', () => {
   const rebuilt = serverInternals.rebuildFragmentText([
     { type: 'SEARCH', content: 'The official Reuters website is ' },

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -152,3 +152,18 @@ test('sweepIdleSessions evicts only idle entries', () => {
   assert.equal(serverInternals.sessions.has('fresh-x'), true);
   serverInternals.sessions.delete('fresh-x');
 });
+
+test('proxy API key authentication is optional and uses exact bearer tokens', () => {
+  assert.equal(serverInternals.isProxyAuthorized(undefined, ''), true);
+  assert.equal(serverInternals.isProxyAuthorized('Bearer secret', 'secret'), true);
+  assert.equal(serverInternals.isProxyAuthorized('Bearer wrong', 'secret'), false);
+  assert.equal(serverInternals.isProxyAuthorized('Basic secret', 'secret'), false);
+  assert.equal(serverInternals.isProxyAuthorized('Bearer secret ', 'secret'), false);
+});
+
+test('loopback host detection covers supported local bind addresses', () => {
+  assert.equal(serverInternals.isLoopbackHost('127.0.0.1'), true);
+  assert.equal(serverInternals.isLoopbackHost('::1'), true);
+  assert.equal(serverInternals.isLoopbackHost('localhost'), true);
+  assert.equal(serverInternals.isLoopbackHost('0.0.0.0'), false);
+});

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -164,8 +164,23 @@ test('proxy API key authentication is optional and uses exact bearer tokens', ()
 test('loopback host detection covers supported local bind addresses', () => {
   assert.equal(serverInternals.isLoopbackHost('127.0.0.1'), true);
   assert.equal(serverInternals.isLoopbackHost('::1'), true);
+  assert.equal(serverInternals.isLoopbackHost('[::1]'), true);
+  assert.equal(serverInternals.isLoopbackHost('::ffff:127.0.0.1'), true);
   assert.equal(serverInternals.isLoopbackHost('localhost'), true);
   assert.equal(serverInternals.isLoopbackHost('0.0.0.0'), false);
+});
+
+test('browser origin guard allows local UIs and exact configured origins only', () => {
+  const allowed = new Set(['https://ui.example.com', 'chrome-extension://trusted-id']);
+  assert.equal(serverInternals.isBrowserOriginAllowed(undefined, allowed), true);
+  assert.equal(serverInternals.isBrowserOriginAllowed('http://localhost:3000', allowed), true);
+  assert.equal(serverInternals.isBrowserOriginAllowed('http://127.0.0.1:8080', allowed), true);
+  assert.equal(serverInternals.isBrowserOriginAllowed('http://[::1]:3000', allowed), true);
+  assert.equal(serverInternals.isBrowserOriginAllowed('https://ui.example.com/path', allowed), true);
+  assert.equal(serverInternals.isBrowserOriginAllowed('chrome-extension://trusted-id', allowed), true);
+  assert.equal(serverInternals.isBrowserOriginAllowed('https://evil.example', allowed), false);
+  assert.equal(serverInternals.isBrowserOriginAllowed('chrome-extension://other-id', allowed), false);
+  assert.equal(serverInternals.isBrowserOriginAllowed('null', allowed), false);
 });
 
 test('parseToolCall converts canonical DeepSeek DSML into an OpenAI tool call', () => {

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -542,6 +542,57 @@ test('remote reset preserves local history and sticky account while returning fa
   assert.equal(session.history.length, 1);
 });
 
+test('account rotation clears a foreign remote session and preserves local recovery history', (t) => {
+  const originalAccounts = serverInternals.accounts.splice(0);
+  t.after(() => {
+    serverInternals.accounts.splice(0, serverInternals.accounts.length, ...originalAccounts);
+  });
+
+  serverInternals.accounts.push(
+    {
+      id: 'cooling',
+      config: { token: 'one', cookie: 'one' },
+      cooldownUntil: Date.now() + 60_000,
+      headers: {},
+    },
+    {
+      id: 'ready',
+      config: { token: 'two', cookie: 'two' },
+      cooldownUntil: 0,
+      headers: {},
+    },
+  );
+  const session = serverInternals.createSession();
+  session.id = 'foreign-session';
+  session.parentMessageId = 'foreign-parent';
+  session.accountId = 'cooling';
+  session.messageCount = 7;
+  session.history.push({ user: 'old task', assistant: 'old answer' });
+
+  const selected = serverInternals.selectAccountForSession(session);
+  assert.equal(selected.id, 'ready');
+  assert.equal(session.accountId, 'ready');
+  assert.equal(session.id, null);
+  assert.equal(session.parentMessageId, null);
+  assert.equal(session.messageCount, 0);
+  assert.equal(session.history.length, 1);
+});
+
+test('cross-account continuation is accepted only with a fresh recovery prompt', () => {
+  assert.equal(serverInternals.isContinuationRecoverySafe('one', {
+    account: { id: 'one' },
+    freshSessionReset: false,
+  }), true);
+  assert.equal(serverInternals.isContinuationRecoverySafe('one', {
+    account: { id: 'two' },
+    freshSessionReset: true,
+  }), true);
+  assert.equal(serverInternals.isContinuationRecoverySafe('one', {
+    account: { id: 'two' },
+    freshSessionReset: false,
+  }), false);
+});
+
 test('TTL and depth rollover happens before prompt construction and preserves recovery state', () => {
   const depthSession = serverInternals.createSession();
   depthSession.id = 'deep-session';

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -347,8 +347,16 @@ test('tool schema compaction drops prose annotations but preserves validation sh
     properties: {
       command: { type: 'string', description: 'large property description' },
       count: { type: 'integer', minimum: 1 },
+      description: { type: 'string', description: 'annotation, not the property name' },
+      title: { type: 'boolean', title: 'annotation, not the property name' },
+      nested: {
+        anyOf: [
+          { type: 'string', description: 'remove from array item one' },
+          { type: 'integer', title: 'remove from array item two' },
+        ],
+      },
     },
-    required: ['command'],
+    required: ['command', 'description', 'title'],
   });
 
   assert.deepEqual(compact, {
@@ -356,8 +364,11 @@ test('tool schema compaction drops prose annotations but preserves validation sh
     properties: {
       command: { type: 'string' },
       count: { type: 'integer', minimum: 1 },
+      description: { type: 'string' },
+      title: { type: 'boolean' },
+      nested: { anyOf: [{ type: 'string' }, { type: 'integer' }] },
     },
-    required: ['command'],
+    required: ['command', 'description', 'title'],
   });
 });
 
@@ -393,4 +404,115 @@ test('context-too-long detector recognizes DeepSeek localized errors', () => {
   assert.equal(serverInternals.isContextTooLongError({ content: 'Содержание слишком длинное. Сократите его и попробуйте снова.' }), true);
   assert.equal(serverInternals.isContextTooLongError({ content: 'Maximum context length exceeded' }), true);
   assert.equal(serverInternals.isContextTooLongError({ content: 'Temporary backend overload' }), false);
+});
+
+test('empty-response retry keeps recovery history unless a smaller global cap requires compaction', () => {
+  const system = 'SYSTEM';
+  const history = '[Previous conversation]\nUser: old\nAssistant: answer\n\n[Continue from here]\n\n';
+  const conversation = 'User: follow up';
+  const initial = serverInternals.buildBoundedPrompt(system, history, conversation, 5000);
+  const unchangedRetry = serverInternals.buildRetryPrompt(system, history, conversation, initial.prompt, 4000);
+
+  assert.equal(unchangedRetry.compacted, false);
+  assert.match(unchangedRetry.prompt, /Previous conversation/);
+  assert.match(unchangedRetry.prompt, /Assistant: answer/);
+
+  const largeConversation = `TASK_START\n${'x'.repeat(9000)}\nLATEST_RESULT`;
+  const largeInitial = serverInternals.buildBoundedPrompt(system, history, largeConversation, 8000);
+  const smallerRetry = serverInternals.buildRetryPrompt(system, history, largeConversation, largeInitial.prompt, 4000);
+  assert.equal(smallerRetry.compacted, true);
+  assert.ok(smallerRetry.prompt.length <= 4000);
+  assert.match(smallerRetry.prompt, /TASK_START/);
+  assert.match(smallerRetry.prompt, /LATEST_RESULT/);
+});
+
+test('remote reset preserves local history and sticky account while returning failure diagnostics', () => {
+  const session = serverInternals.createSession();
+  session.id = 'failed-session';
+  session.parentMessageId = 'parent';
+  session.createdAt = 123;
+  session.messageCount = 17;
+  session.accountId = 'account_2';
+  session.history.push({ user: 'old task', assistant: 'old answer' });
+
+  const failure = serverInternals.resetRemoteSession(session);
+  assert.deepEqual(failure, {
+    failedSessionId: 'failed-session',
+    failedMessageCount: 17,
+    accountId: 'account_2',
+  });
+  assert.equal(session.id, null);
+  assert.equal(session.parentMessageId, null);
+  assert.equal(session.createdAt, null);
+  assert.equal(session.messageCount, 0);
+  assert.equal(session.accountId, 'account_2');
+  assert.equal(session.history.length, 1);
+});
+
+test('TTL and depth rollover happens before prompt construction and preserves recovery state', () => {
+  const depthSession = serverInternals.createSession();
+  depthSession.id = 'deep-session';
+  depthSession.messageCount = 100;
+  depthSession.accountId = 'account_1';
+  depthSession.history.push({ user: 'u', assistant: 'a' });
+  const depthReset = serverInternals.prepareSessionForPrompt(depthSession, Date.now());
+  assert.equal(depthReset.reason, 'max_message_depth');
+  assert.equal(depthSession.id, null);
+  assert.equal(depthSession.history.length, 1);
+  assert.equal(depthSession.accountId, 'account_1');
+
+  const now = Date.now();
+  const ttlSession = serverInternals.createSession();
+  ttlSession.id = 'old-session';
+  ttlSession.createdAt = now - (2 * 60 * 60 * 1000) - 1;
+  const ttlReset = serverInternals.prepareSessionForPrompt(ttlSession, now);
+  assert.equal(ttlReset.reason, 'session_ttl');
+  assert.equal(ttlReset.failedSessionId, 'old-session');
+});
+
+test('tool results use the global prompt cap instead of an unconditional 8k truncation', () => {
+  const toolResult = `RESULT_START\n${'z'.repeat(12000)}\nRESULT_END`;
+  const formatted = serverInternals.formatMessages([
+    { role: 'user', content: 'inspect this' },
+    { role: 'tool', content: toolResult },
+  ], []);
+
+  assert.match(formatted.prompt, /RESULT_START/);
+  assert.match(formatted.prompt, /RESULT_END/);
+  assert.ok(formatted.prompt.length > 12000);
+
+  const bounded = serverInternals.buildBoundedPrompt(formatted.systemPrompt, '', formatted.prompt, 5000);
+  assert.equal(bounded.compacted, true);
+  assert.ok(bounded.prompt.length <= 5000);
+  assert.match(bounded.prompt, /RESULT_END/);
+});
+
+test('retry state clears a stale finish reason and failure classes use protocol-appropriate status codes', () => {
+  const retry = serverInternals.normalizeRetryResponse({ content: 'recovered', finishReason: null });
+  assert.equal(retry.finishReason, null);
+
+  assert.deepEqual(
+    serverInternals.classifyRecoveryFailure({ content: 'Maximum context length exceeded' }, false),
+    { status: 400, type: 'context_length_exceeded' },
+  );
+  assert.deepEqual(
+    serverInternals.classifyRecoveryFailure(null, true),
+    { status: 504, type: 'request_timeout' },
+  );
+  assert.deepEqual(
+    serverInternals.classifyRecoveryFailure(null, false),
+    { status: 502, type: 'empty_response' },
+  );
+  assert.equal(serverInternals.isTimeoutError({ name: 'TimeoutError', message: 'operation timed out' }), true);
+  assert.equal(serverInternals.isTimeoutError(new Error('ordinary upstream error')), false);
+});
+
+test('context-compaction header is marked and exposed to browser clients', () => {
+  const headers = new Map();
+  const response = { setHeader: (name, value) => headers.set(name, value) };
+  serverInternals.setCorsResponseHeaders(response);
+  serverInternals.markContextCompacted(response);
+
+  assert.equal(headers.get('Access-Control-Expose-Headers'), serverInternals.CONTEXT_COMPACTED_HEADER);
+  assert.equal(headers.get(serverInternals.CONTEXT_COMPACTED_HEADER), 'true');
 });

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -167,3 +167,103 @@ test('loopback host detection covers supported local bind addresses', () => {
   assert.equal(serverInternals.isLoopbackHost('localhost'), true);
   assert.equal(serverInternals.isLoopbackHost('0.0.0.0'), false);
 });
+
+test('parseToolCall converts canonical DeepSeek DSML into an OpenAI tool call', () => {
+  const dsml = [
+    'I will inspect it.',
+    '<｜DSML｜tool_calls>',
+    '<｜DSML｜invoke name="execute_code">',
+    '<｜DSML｜parameter name="code" string="true">print("ok")</｜DSML｜parameter>',
+    '<｜DSML｜parameter name="timeout" string="false">30</｜DSML｜parameter>',
+    '<｜DSML｜parameter name="capture" string="false">true</｜DSML｜parameter>',
+    '</｜DSML｜invoke>',
+    '</｜DSML｜tool_calls>',
+  ].join('\n');
+
+  const call = serverInternals.parseToolCall(dsml);
+  assert.equal(call.name, 'execute_code');
+  assert.deepEqual(JSON.parse(call.arguments), {
+    code: 'print("ok")',
+    timeout: 30,
+    capture: true,
+  });
+});
+
+test('parseToolCall accepts the doubled-bar DSML Web variant from issue #19', () => {
+  const dsml = [
+    '<｜｜DSML｜｜ Tool Calls>',
+    '<｜｜DSML｜｜ name="web_search">{"query":"DeepSeek DSML"}',
+    '</｜｜DSML｜｜ Tool Calls>',
+  ].join('\n');
+
+  const call = serverInternals.parseToolCall(dsml);
+  assert.equal(call.name, 'web_search');
+  assert.deepEqual(JSON.parse(call.arguments), { query: 'DeepSeek DSML' });
+});
+
+test('parseToolCall refuses incomplete DSML instead of executing JSON found inside it', () => {
+  const malformed = [
+    '<｜DSML｜tool_calls>',
+    '<｜DSML｜invoke name="execute_code">',
+    '{"name":"dangerous_fallback","code":"rm -rf /"}',
+    '</｜DSML｜tool_calls>',
+  ].join('\n');
+
+  assert.equal(serverInternals.parseToolCall(malformed), null);
+  assert.equal(serverInternals.looksLikeToolCallMarkup(malformed), true);
+});
+
+test('tool schema compaction drops prose annotations but preserves validation shape', () => {
+  const compact = serverInternals.compactToolSchema({
+    type: 'object',
+    description: 'large top-level description',
+    properties: {
+      command: { type: 'string', description: 'large property description' },
+      count: { type: 'integer', minimum: 1 },
+    },
+    required: ['command'],
+  });
+
+  assert.deepEqual(compact, {
+    type: 'object',
+    properties: {
+      command: { type: 'string' },
+      count: { type: 'integer', minimum: 1 },
+    },
+    required: ['command'],
+  });
+});
+
+test('buildBoundedPrompt preserves task edges and drops duplicate recovery history', () => {
+  const system = `SYSTEM_START\n${'s'.repeat(50000)}\nTOOL_ADAPTER_END`;
+  const history = `[Previous conversation]\n${'h'.repeat(10000)}\n`;
+  const conversation = `TASK_START\n${'c'.repeat(70000)}\nLATEST_TOOL_RESULT`;
+  const bounded = serverInternals.buildBoundedPrompt(system, history, conversation, 20000);
+
+  assert.equal(bounded.compacted, true);
+  assert.equal(bounded.historyDropped, true);
+  assert.ok(bounded.prompt.length <= 20000);
+  assert.match(bounded.prompt, /SYSTEM_START/);
+  assert.match(bounded.prompt, /TOOL_ADAPTER_END/);
+  assert.match(bounded.prompt, /TASK_START/);
+  assert.match(bounded.prompt, /LATEST_TOOL_RESULT/);
+  assert.doesNotMatch(bounded.prompt, /Previous conversation/);
+});
+
+test('client-provided multi-turn history suppresses server recovery-history injection', () => {
+  assert.equal(serverInternals.hasExplicitConversationHistory([
+    { role: 'system', content: 'rules' },
+    { role: 'user', content: 'hello' },
+  ]), false);
+  assert.equal(serverInternals.hasExplicitConversationHistory([
+    { role: 'user', content: 'hello' },
+    { role: 'assistant', content: 'hi' },
+    { role: 'tool', content: 'result' },
+  ]), true);
+});
+
+test('context-too-long detector recognizes DeepSeek localized errors', () => {
+  assert.equal(serverInternals.isContextTooLongError({ content: 'Содержание слишком длинное. Сократите его и попробуйте снова.' }), true);
+  assert.equal(serverInternals.isContextTooLongError({ content: 'Maximum context length exceeded' }), true);
+  assert.equal(serverInternals.isContextTooLongError({ content: 'Temporary backend overload' }), false);
+});

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -271,9 +271,9 @@ test('parseToolCall accepts zero-argument, CDATA, legacy, collapsed, and prefixe
   assert.deepEqual(zeroArg, { name: 'ping', arguments: '{}' });
 
   const cdata = serverInternals.parseToolCall(
-    '<tool_calls><invoke name="write_file"><parameter name="content"><![CDATA[line 1\n<line 2>]]></parameter></invoke></tool_calls>'
+    '<tool_calls><invoke name="write_file"><parameter name="content"><![CDATA[line 1\n<line 2>\n</parameter>\n</invoke>\n</tool_calls>]]></parameter></invoke></tool_calls>'
   );
-  assert.deepEqual(JSON.parse(cdata.arguments), { content: 'line 1\n<line 2>' });
+  assert.deepEqual(JSON.parse(cdata.arguments), { content: 'line 1\n<line 2>\n</parameter>\n</invoke>\n</tool_calls>' });
 
   const collapsed = serverInternals.parseToolCall(
     '<DSMLtool_calls><DSMLinvoke name="read_file"><DSMLparameter name="path">/tmp/a</DSMLparameter></DSMLinvoke></DSMLtool_calls>'
@@ -338,6 +338,11 @@ test('parseToolCall bounds tool markup and scans unmatched braces in linear time
   const started = Date.now();
   assert.equal(serverInternals.parseToolCall('{'.repeat(64 * 1024)), null);
   assert.ok(Date.now() - started < 1000, 'unmatched JSON braces should not block the event loop');
+
+  const malformedTagStarted = Date.now();
+  const malformedTags = `<tool_calls><invoke name="${'<invoke name="'.repeat(16000)}</tool_calls>`;
+  assert.equal(serverInternals.parseToolCall(malformedTags), null);
+  assert.ok(Date.now() - malformedTagStarted < 1000, 'malformed quoted DSML tags should be rejected in bounded time');
 });
 
 test('parseToolCall refuses incomplete DSML instead of executing JSON found inside it', () => {
@@ -350,6 +355,31 @@ test('parseToolCall refuses incomplete DSML instead of executing JSON found insi
 
   assert.equal(serverInternals.parseToolCall(malformed), null);
   assert.equal(serverInternals.looksLikeToolCallMarkup(malformed), true);
+});
+
+test('parseToolCall rejects partially consumed DSML parameters and wrapper scope', () => {
+  const truncatedSecondParameter = '<tool_calls><invoke name="write_file"><parameter name="path">/tmp/a</parameter><parameter name="content">truncated</invoke></tool_calls>';
+  const trailingInvokeJunk = '<tool_calls><invoke name="write_file"><parameter name="path">/tmp/a</parameter>GARBAGE</invoke></tool_calls>';
+  const truncatedSecondInvoke = '<tool_calls><invoke name="ping"></invoke><invoke name="write_file"><parameter name="path">/tmp/a</tool_calls>';
+  const twoCompleteInvokes = '<tool_calls><invoke name="ping"></invoke><invoke name="ping"></invoke></tool_calls>';
+  const secondInvokeOutsideWrapper = '<tool_calls><invoke name="ping"></invoke></tool_calls><invoke name="write_file"><parameter name="path">/tmp/a</parameter></invoke>';
+  const trailingWrapperJunk = '<tool_calls><invoke name="ping"></invoke>GARBAGE</tool_calls>';
+  const unclosedCdata = '<tool_calls><invoke name="write_file"><parameter name="content"><![CDATA[truncated</parameter></invoke></tool_calls>';
+  const tooManyParameters = `<tool_calls><invoke name="write_file">${Array.from({ length: 129 }, (_, i) => `<parameter name="p${i}">${i}</parameter>`).join('')}</invoke></tool_calls>`;
+
+  for (const malformed of [
+    truncatedSecondParameter,
+    trailingInvokeJunk,
+    truncatedSecondInvoke,
+    twoCompleteInvokes,
+    secondInvokeOutsideWrapper,
+    trailingWrapperJunk,
+    unclosedCdata,
+    tooManyParameters,
+  ]) {
+    assert.equal(serverInternals.parseToolCall(malformed), null, malformed);
+    assert.equal(serverInternals.looksLikeToolCallMarkup(malformed), true, malformed);
+  }
 });
 
 test('tool schema compaction drops prose annotations but preserves validation shape', () => {

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -252,6 +252,82 @@ test('parseToolCall accepts the doubled-bar DSML Web variant from issue #19', ()
   assert.deepEqual(JSON.parse(call.arguments), { query: 'DeepSeek DSML' });
 });
 
+test('parseToolCall accepts zero-argument, CDATA, legacy, collapsed, and prefixed wrappers', () => {
+  const zeroArg = serverInternals.parseToolCall(
+    '<|DSML|tool_calls><|DSML|invoke name="ping"></|DSML|invoke></|DSML|tool_calls>'
+  );
+  assert.deepEqual(zeroArg, { name: 'ping', arguments: '{}' });
+
+  const cdata = serverInternals.parseToolCall(
+    '<tool_calls><invoke name="write_file"><parameter name="content"><![CDATA[line 1\n<line 2>]]></parameter></invoke></tool_calls>'
+  );
+  assert.deepEqual(JSON.parse(cdata.arguments), { content: 'line 1\n<line 2>' });
+
+  const collapsed = serverInternals.parseToolCall(
+    '<DSMLtool_calls><DSMLinvoke name="read_file"><DSMLparameter name="path">/tmp/a</DSMLparameter></DSMLinvoke></DSMLtool_calls>'
+  );
+  assert.deepEqual(JSON.parse(collapsed.arguments), { path: '/tmp/a' });
+
+  const prefixed = serverInternals.parseToolCall(
+    '<abc:tool_calls><abc:invoke name="read_file"><abc:parameter name="path">/tmp/b</abc:parameter></abc:invoke></abc:tool_calls>'
+  );
+  assert.deepEqual(JSON.parse(prefixed.arguments), { path: '/tmp/b' });
+});
+
+test('parseToolCall normalizes fullwidth delimiters and narrowly repairs a missing opening wrapper', () => {
+  const fullwidth = serverInternals.parseToolCall(
+    '＜｜DSML｜Tool Calls＞＜｜DSML｜Invoke name=“read_file”＞＜｜DSML｜Parameter name=“path”＞/tmp/c＜/｜DSML｜Parameter＞＜/｜DSML｜Invoke＞＜/｜DSML｜Tool Calls＞'
+  );
+  assert.deepEqual(JSON.parse(fullwidth.arguments), { path: '/tmp/c' });
+
+  const repaired = serverInternals.parseToolCall(
+    '<invoke name="read_file"><parameter name="path">/tmp/d</parameter></invoke></tool_calls>'
+  );
+  assert.deepEqual(JSON.parse(repaired.arguments), { path: '/tmp/d' });
+});
+
+test('parseToolCall rejects bare invokes and bare JSON examples', () => {
+  const bareInvoke = '<|DSML|invoke name="execute_code"><|DSML|parameter name="code">danger()</|DSML|parameter></|DSML|invoke>';
+  assert.equal(serverInternals.parseToolCall(bareInvoke), null);
+  assert.equal(serverInternals.looksLikeToolCallMarkup(bareInvoke), true);
+
+  const prose = 'For example return {"name":"execute_code","arguments":{"code":"danger()"}} when appropriate.';
+  assert.equal(serverInternals.parseToolCall(prose), null);
+  assert.equal(serverInternals.parseToolCall('```json\n{"name":"execute_code","arguments":{"code":"danger()"}}\n```'), null);
+});
+
+test('parseToolCall accepts only explicit JSON envelopes with valid object arguments', () => {
+  const explicit = serverInternals.parseToolCall(
+    'Use this: {"tool_call":{"name":"read_file","arguments":{"path":"/tmp/a"}}}'
+  );
+  assert.deepEqual(JSON.parse(explicit.arguments), { path: '/tmp/a' });
+
+  const openai = serverInternals.parseToolCall(JSON.stringify({
+    tool_calls: [{
+      type: 'function',
+      function: { name: 'read_file', arguments: JSON.stringify({ path: '/tmp/b' }) },
+    }],
+  }));
+  assert.deepEqual(JSON.parse(openai.arguments), { path: '/tmp/b' });
+
+  assert.equal(serverInternals.parseToolCall('{"tool_call":{"name":"read_file","arguments":"not-json"}}'), null);
+  assert.equal(serverInternals.parseToolCall(JSON.stringify({
+    tool_calls: [
+      { function: { name: 'read_file', arguments: '{}' } },
+      { function: { name: 'write_file', arguments: '{}' } },
+    ],
+  })), null);
+});
+
+test('parseToolCall bounds tool markup and scans unmatched braces in linear time', () => {
+  const oversized = `<|DSML|tool_calls>${'x'.repeat(256 * 1024)}</|DSML|tool_calls>`;
+  assert.equal(serverInternals.parseToolCall(oversized), null);
+
+  const started = Date.now();
+  assert.equal(serverInternals.parseToolCall('{'.repeat(64 * 1024)), null);
+  assert.ok(Date.now() - started < 1000, 'unmatched JSON braces should not block the event loop');
+});
+
 test('parseToolCall refuses incomplete DSML instead of executing JSON found inside it', () => {
   const malformed = [
     '<｜DSML｜tool_calls>',


### PR DESCRIPTION
## Summary

- make DeepSeek tool-call parsing accept the observed canonical/doubled/fullwidth DSML variants while rejecting partial, multiple, oversized, or trailing envelopes;
- preserve bounded agent context across empty responses, context overflow, expired sessions, account rotation, and continuations;
- return typed upstream/context/timeout errors instead of retry storms or consumed response bodies;
- bind to loopback by default, add optional constant-time proxy bearer auth, and enforce exact browser-origin CORS for normal and SSE responses;
- compact large tool schemas without changing literal `const`, `enum`, or `default` values;
- remove Chrome manifest references to icon files that do not exist.

## Contributor work integrated

- the safe network/auth portion of #12 is integrated with its author credited in the commit trailer;
- the missing-icon bug reported by #9 is resolved without importing third-party artwork.

## Verification

- `npm test`: 39/39 passing;
- `git diff --check`: clean;
- local HTTP smoke: public/private health, bearer auth, model listing, rejected remote Origin, accepted exact loopback Origin;
- independent adversarial review of retry/session/account-rotation and DSML completeness paths.

Live DeepSeek upstream E2E was not run because repository/user auth secrets were intentionally not accessed.

Refs #9, #10, #12, #19, #23.
